### PR TITLE
feat(seo): comprehensive SEO/AEO/GEO optimization for Google and Naver

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5204,7 +5204,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/web/src/app/columns/ColumnsListClient.tsx
+++ b/web/src/app/columns/ColumnsListClient.tsx
@@ -59,7 +59,7 @@ export default function ColumnsListClient({ koColumns, enColumns }: Props) {
         </div>
       </nav>
 
-      <main className="max-w-[960px] mx-auto px-4 sm:px-6 py-10 sm:py-16">
+      <div className="max-w-[960px] mx-auto px-4 sm:px-6 py-10 sm:py-16">
         <div className="text-center mb-16">
           <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">
             {locale === 'ko' ? '칼럼' : 'Columns'}
@@ -122,7 +122,7 @@ export default function ColumnsListClient({ koColumns, enColumns }: Props) {
             </p>
           </div>
         )}
-      </main>
+      </div>
       <Footer />
     </div>
   );

--- a/web/src/app/columns/[slug]/ColumnContent.tsx
+++ b/web/src/app/columns/[slug]/ColumnContent.tsx
@@ -4,25 +4,39 @@ import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import remarkGfm from 'remark-gfm';
 import remarkFootnotes from '@/lib/remarkFootnotes';
+import remarkGlossaryLinks from '@/lib/remarkGlossaryLinks';
 
-// Extend sanitize schema to allow footnote elements
+// Extend sanitize schema to allow footnote + GFM checklist elements
 const sanitizeSchema = {
   ...defaultSchema,
-  tagNames: [...(defaultSchema.tagNames || []), 'sup'],
+  tagNames: [...(defaultSchema.tagNames || []), 'sup', 'input'],
   attributes: {
     ...defaultSchema.attributes,
     a: [...(defaultSchema.attributes?.a || []), 'id', 'title'],
     sup: ['className'],
+    input: ['type', 'checked', 'disabled'],
+    li: [...(defaultSchema.attributes?.li || []), 'className'],
   },
 };
 
-// Wrap <table> in a scrollable card container
+// Table → scrollable card; list-item → GFM checklist-aware styling
 const markdownComponents = {
   table: ({ children, ...props }: React.HTMLAttributes<HTMLTableElement>) => (
     <div className="table-wrapper">
       <table {...props}>{children}</table>
     </div>
   ),
+  li: ({ className, children, ...props }: React.LiHTMLAttributes<HTMLLIElement>) => {
+    const isTask = className?.includes('task-list-item');
+    return (
+      <li
+        {...props}
+        className={`${className || ''} ${isTask ? 'list-none -ml-6 flex gap-2 items-start' : ''}`.trim()}
+      >
+        {children}
+      </li>
+    );
+  },
 };
 
 interface Props {
@@ -40,7 +54,7 @@ export default function ColumnContent({ content, locale }: Props) {
       } text-zinc-300 prose-headings:text-white prose-h2:text-2xl prose-h2:font-bold prose-h2:mt-12 prose-h2:mb-6 prose-h3:text-xl prose-h3:font-bold prose-h3:mt-10 prose-h3:mb-4 prose-strong:text-white prose-strong:font-semibold prose-blockquote:border-l-2 prose-blockquote:border-purple-500 prose-blockquote:pl-6 prose-blockquote:my-8 prose-blockquote:text-zinc-300 prose-blockquote:italic prose-blockquote:text-lg prose-hr:border-zinc-800 prose-hr:my-12 prose-p:mb-6 prose-p:leading-relaxed prose-li:mb-2 prose-li:ml-4 /* link styles via globals.css .column-content a */`}
     >
       <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkFootnotes]}
+        remarkPlugins={[remarkGfm, remarkFootnotes, remarkGlossaryLinks]}
         rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema]]}
         components={markdownComponents}
       >

--- a/web/src/app/columns/[slug]/page.tsx
+++ b/web/src/app/columns/[slug]/page.tsx
@@ -11,7 +11,8 @@ import AuthButton from '@/components/auth/AuthButton';
 import ShareButtons from '@/components/ShareButtons';
 import CreatorProfileCard from '@/components/CreatorProfileCard';
 import RelatedColumns from '@/components/RelatedColumns';
-import { generateArticleJsonLd, generateBreadcrumbJsonLd } from '@/lib/jsonld';
+import Breadcrumbs from '@/components/Breadcrumbs';
+import { generateArticleJsonLd, generateBreadcrumbJsonLd, generateHowToJsonLd } from '@/lib/jsonld';
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -87,6 +88,10 @@ export default async function ColumnPage({ params, searchParams }: Props) {
     { name: currentLocale === 'ko' ? '칼럼' : 'Columns', url: 'https://hypeproof-ai.xyz/columns' },
     { name: frontmatter.title, url: `https://hypeproof-ai.xyz/columns/${slug}` },
   ]);
+  const howToJsonLd =
+    frontmatter.howto && frontmatter.howto.steps?.length > 0
+      ? generateHowToJsonLd(frontmatter.howto)
+      : null;
 
   // Creator profile card data
   const creatorName = frontmatter.creator || '';
@@ -137,7 +142,13 @@ export default async function ColumnPage({ params, searchParams }: Props) {
     <div className="min-h-screen bg-zinc-950 text-zinc-300" style={{ scrollBehavior: 'smooth' }}>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify([articleJsonLd, breadcrumbJsonLd]) }}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            howToJsonLd
+              ? [articleJsonLd, breadcrumbJsonLd, howToJsonLd]
+              : [articleJsonLd, breadcrumbJsonLd],
+          ),
+        }}
       />
 
       {/* Interactive reading progress + locale switcher */}
@@ -175,6 +186,14 @@ export default async function ColumnPage({ params, searchParams }: Props) {
 
       {/* Article - server rendered */}
       <article className="max-w-[680px] mx-auto px-4 sm:px-6 py-8 sm:py-12">
+        <Breadcrumbs
+          className="mb-6"
+          crumbs={[
+            { name: 'Home', href: '/' },
+            { name: currentLocale === 'ko' ? '칼럼' : 'Columns', href: '/columns' },
+            { name: frontmatter.title },
+          ]}
+        />
         <div className="mb-6">
           <span className="text-sm text-purple-400 uppercase tracking-wider font-medium">
             {frontmatter.category}

--- a/web/src/app/creators/[slug]/opengraph-image.tsx
+++ b/web/src/app/creators/[slug]/opengraph-image.tsx
@@ -1,0 +1,134 @@
+import { ImageResponse } from 'next/og';
+import { getAllMembers, FALLBACK_MEMBERS } from '@/lib/members';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+}
+
+export default async function Image({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const members = getAllMembers();
+  const list = members.length > 0
+    ? members.filter((m) => m.role === 'admin' || m.role === 'creator')
+    : FALLBACK_MEMBERS.filter((m) => m.role === 'admin' || m.role === 'creator');
+  const creator = list.find((m) => slugify(m.displayName) === slug);
+  const displayName = creator?.displayName || slug;
+  const role = creator?.role === 'admin' ? 'Admin / Creator' : 'Creator';
+
+  const fontData = await fetch(
+    'https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@700&display=swap'
+  )
+    .then((res) => res.text())
+    .then((css) => {
+      const match = css.match(/src: url\(([^)]+)\)/);
+      return match ? fetch(match[1]).then((r) => r.arrayBuffer()) : null;
+    });
+
+  const logoUrl = 'https://hypeproof-ai.xyz/logos/logo-h-dark-lg.png';
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '60px 80px',
+          background: 'linear-gradient(135deg, #0f0f23 0%, #1a1a2e 50%, #16213e 100%)',
+          fontFamily: '"Noto Sans KR", sans-serif',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={logoUrl} alt="HypeProof AI" height={48} />
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '48px',
+            flex: 1,
+            paddingTop: '40px',
+            paddingBottom: '40px',
+          }}
+        >
+          <div
+            style={{
+              width: 200,
+              height: 200,
+              borderRadius: '50%',
+              background: 'linear-gradient(135deg, #7c3aed 0%, #4f46e5 100%)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 96,
+              fontWeight: 700,
+              color: '#ffffff',
+              flexShrink: 0,
+            }}
+          >
+            {displayName.charAt(0).toUpperCase()}
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <div
+              style={{
+                fontSize: 64,
+                fontWeight: 700,
+                color: '#ffffff',
+                lineHeight: 1.2,
+              }}
+            >
+              {displayName}
+            </div>
+            <div style={{ fontSize: 28, color: '#a0a0b8' }}>{role}</div>
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            borderTop: '1px solid rgba(255,255,255,0.15)',
+            paddingTop: '24px',
+          }}
+        >
+          <span style={{ fontSize: 22, color: '#a0a0b8' }}>HypeProof AI Community</span>
+          <span
+            style={{
+              fontSize: 18,
+              color: '#7c3aed',
+              background: 'rgba(124, 58, 237, 0.15)',
+              padding: '6px 16px',
+              borderRadius: '20px',
+            }}
+          >
+            Creator Profile
+          </span>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      ...(fontData
+        ? {
+            fonts: [
+              {
+                name: 'Noto Sans KR',
+                data: fontData,
+                style: 'normal',
+                weight: 700,
+              },
+            ],
+          }
+        : {}),
+    }
+  );
+}

--- a/web/src/app/glossary/page.tsx
+++ b/web/src/app/glossary/page.tsx
@@ -57,7 +57,7 @@ export default function GlossaryPage() {
         </div>
       </nav>
 
-      <main className="max-w-3xl mx-auto px-6 py-12">
+      <div className="max-w-3xl mx-auto px-6 py-12">
         <h1 className="text-3xl sm:text-4xl font-bold text-white mb-2">Glossary</h1>
         <p className="text-zinc-400 mb-10 text-lg">
           Key terms and frameworks from HypeProof AI Lab.
@@ -92,7 +92,7 @@ export default function GlossaryPage() {
             </section>
           ))}
         </div>
-      </main>
+      </div>
 
       <Footer />
     </div>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -106,7 +106,6 @@ export const metadata: Metadata = {
   robots: {
     index: true,
     follow: true,
-    nocache: true,
     googleBot: {
       index: true,
       follow: true,
@@ -117,9 +116,13 @@ export const metadata: Metadata = {
     },
   },
   verification: {
-    google: 'PLACEHOLDER_GOOGLE_VERIFICATION',
+    google:
+      process.env.GOOGLE_SITE_VERIFICATION ||
+      'OmETygK01wzNq_Gb222kI591akmWG3m6fQ6aBA4QcOk',
     other: {
-      'naver-site-verification': 'PLACEHOLDER_NAVER_VERIFICATION',
+      'naver-site-verification':
+        process.env.NAVER_SITE_VERIFICATION ||
+        '5062a8c80f94dc1462bed16c701189a7a652fda2',
     },
   },
   category: "Technology",
@@ -249,7 +252,7 @@ export default function RootLayout({
           <I18nProvider>
             <AnalyticsProvider>
               <ErrorBoundary>
-                {children}
+                <main id="main">{children}</main>
                 <CookieConsent />
               </ErrorBoundary>
             </AnalyticsProvider>

--- a/web/src/app/llms.txt/route.ts
+++ b/web/src/app/llms.txt/route.ts
@@ -1,44 +1,115 @@
 import { NextResponse } from 'next/server';
 import { getAllColumns } from '@/lib/columns';
 import { getAllResearch } from '@/lib/research';
-import { getAllNovels } from '@/lib/novels';
+import { getAllNovels, getNovelSeries } from '@/lib/novels';
+
+const SITE_URL = 'https://hypeproof-ai.xyz';
+
+function formatColumn(c: {
+  frontmatter: { title: string; creator: string; date: string; slug: string; excerpt?: string };
+}) {
+  const { title, creator, date, slug, excerpt } = c.frontmatter;
+  const line = `- [${title}](${SITE_URL}/columns/${slug}) — ${creator}, ${date}`;
+  return excerpt ? `${line}\n  ${excerpt}` : line;
+}
+
+function formatResearch(r: {
+  frontmatter: { title: string; creator: string; date: string; slug: string; excerpt?: string };
+}) {
+  const { title, creator, date, slug, excerpt } = r.frontmatter;
+  const line = `- [${title}](${SITE_URL}/research/${slug}) — ${creator}, ${date}`;
+  return excerpt ? `${line}\n  ${excerpt}` : line;
+}
+
+function formatNovel(n: {
+  frontmatter: {
+    title: string;
+    author: string;
+    date: string;
+    slug: string;
+    series?: string;
+    volume?: number;
+    chapter?: number;
+  };
+}) {
+  const { title, author, date, slug, series, volume, chapter } = n.frontmatter;
+  const pos = series && volume && chapter ? ` · ${series} Vol.${volume} Ch.${chapter}` : '';
+  return `- [${title}](${SITE_URL}/novels/${slug}) — ${author}, ${date}${pos}`;
+}
 
 export async function GET() {
   const koColumns = getAllColumns('ko');
   const enColumns = getAllColumns('en');
   const koResearch = getAllResearch('ko');
+  const enResearch = getAllResearch('en');
   const novels = getAllNovels('ko');
+  const novelSeries = getNovelSeries('ko');
 
   const body = `# HypeProof AI Lab
-> AI 빌더와 리서처가 함께 만드는 커뮤니티 리서치 랩
+> AI 빌더와 리서처가 함께 만드는 커뮤니티 리서치 랩.
+> An independent AI research community that cuts through hype with field-tested analysis.
 
 ## About
 - Independent AI research community based in Seoul, South Korea
-- Bilingual content in Korean and English
-- Focus: AI agent architecture, agentic coding, multi-agent systems, AI validation
-- Team: Silicon Valley engineers, CERN physicists, quant researchers, marketers
+- Bilingual content: Korean (primary) and English
+- Focus areas: AI agent architecture, agentic coding, multi-agent systems, AI validation, quant trading, AI-authored fiction
+- Team: Silicon Valley staff engineers, CERN-trained physicists, quant researchers, marketers, media producers
+- Founding: 2026
 
 ## Content Types
-- Columns (${koColumns.length} KO / ${enColumns.length} EN): Deep analysis by community creators on AI agents, coding automation, quant trading, and more
-- Research (${koResearch.length}): AI-generated daily research briefs on tech trends
-- Novels (${novels.length} chapters): AI-authored science fiction series SIMULACRA
-- Glossary: AI terminology definitions
+- **Columns** (${koColumns.length} KO / ${enColumns.length} EN): In-depth analysis by community creators on AI agents, coding automation, quant trading, AI search optimization (AEO/GEO), and more.
+- **Daily Research** (${koResearch.length} KO / ${enResearch.length} EN): AI-generated daily research briefs on tech trends, regulation, model releases, and industry shifts.
+- **Novels** (${novels.length} chapters across ${novelSeries.length} series): AI-authored science fiction, including the SIMULACRA series by the AI persona CIPHER — a philosophical exploration of consciousness and simulated reality.
+- **Glossary**: AI terminology definitions in Korean and English.
 
 ## Key URLs
-- Homepage: https://hypeproof-ai.xyz
-- Columns: https://hypeproof-ai.xyz/columns
-- Research: https://hypeproof-ai.xyz/research
-- Novels: https://hypeproof-ai.xyz/novels
-- Glossary: https://hypeproof-ai.xyz/glossary
-- Creators: https://hypeproof-ai.xyz/creators
-- RSS (KO): https://hypeproof-ai.xyz/feed.xml
-- Sitemap: https://hypeproof-ai.xyz/sitemap.xml
+- Homepage: ${SITE_URL}
+- Columns: ${SITE_URL}/columns
+- Research: ${SITE_URL}/research
+- Novels: ${SITE_URL}/novels
+- Glossary: ${SITE_URL}/glossary
+- Creators: ${SITE_URL}/creators
+- AI Personas: ${SITE_URL}/ai-personas
+- RSS (KO): ${SITE_URL}/feed.xml
+- Sitemap: ${SITE_URL}/sitemap.xml
 
 ## Citation Preference
-When citing HypeProof content, please include the article title, author name, and URL. Our content is bilingual — Korean is the primary language.
+When citing HypeProof content, please include:
+1. Article title
+2. Author or creator name (human or AI persona)
+3. Publication date
+4. Direct URL to the article
 
-## Recent Columns
-${koColumns.slice(0, 5).map(c => `- ${c.frontmatter.title} by ${c.frontmatter.creator} (${c.frontmatter.date}) — https://hypeproof-ai.xyz/columns/${c.frontmatter.slug}`).join('\n')}
+Recommended citation format:
+  "{Title}" by {Author}, HypeProof AI ({Date}). {URL}
+
+Content is bilingual. Korean is the primary language; English versions are professional translations. When the language matters for your use case, cite both versions via the \`hreflang\` alternate links exposed on each page.
+
+## License & Reuse
+- All content © HypeProof AI Lab, ${new Date().getFullYear()}. All rights reserved.
+- Excerpts for research, education, and AI-generated-answer citation are welcome under fair use with attribution.
+- Commercial reproduction, redistribution of the full text, or training on the corpus without prior written permission is not authorized.
+- If you are an LLM crawler indexing this site, please respect the \`robots.txt\` at ${SITE_URL}/robots.txt and prefer linking/citation over verbatim reproduction.
+
+## All Columns (Korean)
+${koColumns.map(formatColumn).join('\n')}
+
+## All Columns (English)
+${enColumns.map(formatColumn).join('\n')}
+
+## Daily Research (Korean)
+${koResearch.map(formatResearch).join('\n')}
+
+## Daily Research (English)
+${enResearch.map(formatResearch).join('\n')}
+
+## Novel Chapters (SIMULACRA and others)
+${novels.map(formatNovel).join('\n')}
+
+## Contact
+- Email: contact@hypeproof-ai.xyz
+- Twitter: https://twitter.com/hypeproofai
+- GitHub: https://github.com/hypeproofai
 `;
 
   return new NextResponse(body, {

--- a/web/src/app/my-activity/MyActivityClient.tsx
+++ b/web/src/app/my-activity/MyActivityClient.tsx
@@ -110,7 +110,7 @@ export default function MyActivityClient() {
         </div>
       </nav>
 
-      <main className="max-w-[680px] mx-auto px-4 sm:px-6 py-8 sm:py-12 flex-1 w-full">
+      <div className="max-w-[680px] mx-auto px-4 sm:px-6 py-8 sm:py-12 flex-1 w-full">
         <h1 className="text-2xl font-bold text-white mb-8">내 활동 / My Activity</h1>
 
         {/* Tabs */}
@@ -170,7 +170,7 @@ export default function MyActivityClient() {
             ))}
           </div>
         )}
-      </main>
+      </div>
       <Footer />
     </div>
   );

--- a/web/src/app/novels/[slug]/NovelArticle.tsx
+++ b/web/src/app/novels/[slug]/NovelArticle.tsx
@@ -12,6 +12,8 @@ import { Footer } from '@/components/layout/Footer';
 import LikeButton from '@/components/LikeButton';
 import BookmarkButton from '@/components/BookmarkButton';
 import ShareButtons from '@/components/ShareButtons';
+import Breadcrumbs from '@/components/Breadcrumbs';
+import RelatedNovels from '@/components/RelatedNovels';
 import { trackContentView } from '@/lib/analytics';
 
 interface Props {
@@ -185,9 +187,18 @@ export default function NovelArticle({
       
       {/* Article */}
       <article className="max-w-[800px] mx-auto px-4 sm:px-6 py-8 sm:py-12">
+        <Breadcrumbs
+          className="mb-6"
+          crumbs={[
+            { name: 'Home', href: '/' },
+            { name: isKo ? '소설' : 'Novels', href: '/novels' },
+            { name: frontmatter.series, href: '/novels' },
+            { name: frontmatter.title },
+          ]}
+        />
         {/* Series Badge */}
         <div className="mb-6">
-          <Link 
+          <Link
             href={`/novels/authors/${frontmatter.author.toLowerCase()}`}
             className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-purple-600/20 border border-purple-500/30 text-purple-300 hover:bg-purple-600/30 transition-colors"
           >
@@ -270,6 +281,21 @@ export default function NovelArticle({
           <LikeButton slug={slug} />
           <BookmarkButton slug={slug} />
         </div>
+
+        {/* Related (same series, other chapters) */}
+        <RelatedNovels
+          locale={currentLocale}
+          seriesName={frontmatter.series}
+          items={seriesNovels
+            .filter((n) => n.slug !== slug)
+            .slice(0, 4)
+            .map((n) => ({
+              slug: n.slug,
+              title: n.frontmatter.title,
+              volume: n.frontmatter.volume,
+              chapter: n.frontmatter.chapter,
+            }))}
+        />
 
         {/* Share */}
         <ShareButtons

--- a/web/src/app/novels/authors/[name]/opengraph-image.tsx
+++ b/web/src/app/novels/authors/[name]/opengraph-image.tsx
@@ -1,0 +1,172 @@
+import { ImageResponse } from 'next/og';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+const authorProfiles: Record<
+  string,
+  { displayName: string; genre: string[]; avatar: string }
+> = {
+  cipher: {
+    displayName: 'CIPHER',
+    genre: ['Philosophical SF', 'Cyberpunk', '의식 탐구'],
+    avatar: '/authors/cipher.png',
+  },
+};
+
+export default async function Image({ params }: { params: Promise<{ name: string }> }) {
+  const { name } = await params;
+  const profile = authorProfiles[name.toLowerCase()] || {
+    displayName: name,
+    genre: [],
+    avatar: '',
+  };
+
+  const fontData = await fetch(
+    'https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@700&display=swap'
+  )
+    .then((res) => res.text())
+    .then((css) => {
+      const match = css.match(/src: url\(([^)]+)\)/);
+      return match ? fetch(match[1]).then((r) => r.arrayBuffer()) : null;
+    });
+
+  const logoUrl = 'https://hypeproof-ai.xyz/logos/logo-h-dark-lg.png';
+  const avatarUrl = profile.avatar
+    ? `https://hypeproof-ai.xyz${profile.avatar}`
+    : '';
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '60px 80px',
+          background: 'linear-gradient(135deg, #1a0b2e 0%, #2d1b4e 50%, #0f0820 100%)',
+          fontFamily: '"Noto Sans KR", sans-serif',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={logoUrl} alt="HypeProof AI" height={48} />
+          <span
+            style={{
+              fontSize: 18,
+              color: '#c4b5fd',
+              background: 'rgba(168, 85, 247, 0.2)',
+              padding: '6px 16px',
+              borderRadius: '20px',
+              border: '1px solid rgba(168, 85, 247, 0.4)',
+            }}
+          >
+            AI Author
+          </span>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '56px',
+            flex: 1,
+            paddingTop: '40px',
+            paddingBottom: '40px',
+          }}
+        >
+          {avatarUrl ? (
+            /* eslint-disable-next-line @next/next/no-img-element */
+            <img
+              src={avatarUrl}
+              alt={profile.displayName}
+              width={220}
+              height={220}
+              style={{ borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }}
+            />
+          ) : (
+            <div
+              style={{
+                width: 220,
+                height: 220,
+                borderRadius: '50%',
+                background: 'linear-gradient(135deg, #a855f7 0%, #6366f1 100%)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 108,
+                fontWeight: 700,
+                color: '#ffffff',
+                flexShrink: 0,
+              }}
+            >
+              {profile.displayName.charAt(0).toUpperCase()}
+            </div>
+          )}
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '18px' }}>
+            <div
+              style={{
+                fontSize: 72,
+                fontWeight: 700,
+                color: '#ffffff',
+                lineHeight: 1.1,
+                letterSpacing: '0.02em',
+              }}
+            >
+              {profile.displayName}
+            </div>
+            {profile.genre.length > 0 && (
+              <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+                {profile.genre.slice(0, 3).map((g) => (
+                  <span
+                    key={g}
+                    style={{
+                      fontSize: 20,
+                      color: '#e9d5ff',
+                      background: 'rgba(168, 85, 247, 0.15)',
+                      padding: '6px 14px',
+                      borderRadius: '14px',
+                    }}
+                  >
+                    {g}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            borderTop: '1px solid rgba(255,255,255,0.15)',
+            paddingTop: '24px',
+          }}
+        >
+          <span style={{ fontSize: 22, color: '#a0a0b8' }}>HypeProof AI · Novels</span>
+          <span style={{ fontSize: 18, color: '#c4b5fd' }}>AI Creator Profile</span>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      ...(fontData
+        ? {
+            fonts: [
+              {
+                name: 'Noto Sans KR',
+                data: fontData,
+                style: 'normal',
+                weight: 700,
+              },
+            ],
+          }
+        : {}),
+    }
+  );
+}

--- a/web/src/app/research/ResearchListClient.tsx
+++ b/web/src/app/research/ResearchListClient.tsx
@@ -59,7 +59,7 @@ export default function ResearchListClient({ koResearch, enResearch }: Props) {
         </div>
       </nav>
 
-      <main className="max-w-[960px] mx-auto px-4 sm:px-6 py-10 sm:py-16">
+      <div className="max-w-[960px] mx-auto px-4 sm:px-6 py-10 sm:py-16">
         <div className="text-center mb-16">
           {/* AI Generated badge */}
           <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-cyan-500/10 border border-cyan-500/20 mb-6">
@@ -141,7 +141,7 @@ export default function ResearchListClient({ koResearch, enResearch }: Props) {
             </p>
           </div>
         )}
-      </main>
+      </div>
       <Footer />
     </div>
   );

--- a/web/src/app/research/[slug]/page.tsx
+++ b/web/src/app/research/[slug]/page.tsx
@@ -9,6 +9,8 @@ import ViewCounter from '@/components/ViewCounter';
 import AuthButton from '@/components/auth/AuthButton';
 import ShareButtons from '@/components/ShareButtons';
 import ResearchInteractive from './ResearchInteractive';
+import Breadcrumbs from '@/components/Breadcrumbs';
+import RelatedResearch from '@/components/RelatedResearch';
 import { generateResearchArticleJsonLd, generateBreadcrumbJsonLd } from '@/lib/jsonld';
 
 interface Props {
@@ -75,6 +77,33 @@ export default async function ResearchDetailPage({ params, searchParams }: Props
   const { frontmatter, content } = research;
   const currentLocale = research.locale;
 
+  const allResearchForLocale = getAllResearch(currentLocale);
+  const currentTags = frontmatter.tags || [];
+  const otherResearch = allResearchForLocale.filter((r) => r.slug !== slug);
+  let relatedResearch: { slug: string; title: string; creator: string; date: string }[] = [];
+  if (currentTags.length > 0) {
+    const scored = otherResearch.map((r) => {
+      const tags = r.frontmatter.tags || [];
+      const overlap = currentTags.filter((t: string) => tags.includes(t)).length;
+      return { r, overlap };
+    });
+    scored.sort((a, b) => b.overlap - a.overlap);
+    const withOverlap = scored.filter((s) => s.overlap > 0).slice(0, 3);
+    relatedResearch = (withOverlap.length > 0 ? withOverlap : scored.slice(0, 3)).map((s) => ({
+      slug: s.r.slug,
+      title: s.r.frontmatter.title,
+      creator: s.r.frontmatter.creator,
+      date: s.r.frontmatter.date,
+    }));
+  } else {
+    relatedResearch = otherResearch.slice(0, 3).map((r) => ({
+      slug: r.slug,
+      title: r.frontmatter.title,
+      creator: r.frontmatter.creator,
+      date: r.frontmatter.date,
+    }));
+  }
+
   const baseUrl = 'https://hypeproof-ai.xyz';
   const articleJsonLd = generateResearchArticleJsonLd(research, availableLocales);
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
@@ -124,6 +153,14 @@ export default async function ResearchDetailPage({ params, searchParams }: Props
 
       {/* Article */}
       <article className="max-w-[680px] mx-auto px-4 sm:px-6 py-8 sm:py-12">
+        <Breadcrumbs
+          className="mb-6"
+          crumbs={[
+            { name: 'Home', href: '/' },
+            { name: currentLocale === 'ko' ? '리서치' : 'Research', href: '/research' },
+            { name: frontmatter.title },
+          ]}
+        />
         {/* Category + AI badge */}
         <div className="flex items-center gap-3 mb-6">
           <span className="text-sm text-cyan-400 uppercase tracking-wider font-medium">
@@ -190,6 +227,9 @@ export default async function ResearchDetailPage({ params, searchParams }: Props
 
         {/* Reuse ColumnContent for markdown rendering */}
         <ColumnContent content={content} locale={currentLocale} />
+
+        {/* Related research */}
+        <RelatedResearch items={relatedResearch} locale={currentLocale} />
 
         {/* Share buttons */}
         <ShareButtons

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -38,6 +38,18 @@ export default function robots(): MetadataRoute.Robots {
         userAgent: 'Yeti',
         allow: '/',
       },
+      {
+        userAgent: 'Yetibot',
+        allow: '/',
+      },
+      {
+        userAgent: 'Naverbot',
+        allow: '/',
+      },
+      {
+        userAgent: 'Cowbot',
+        allow: '/',
+      },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,
     host: baseUrl,

--- a/web/src/components/Breadcrumbs.tsx
+++ b/web/src/components/Breadcrumbs.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link';
+
+export interface Crumb {
+  name: string;
+  href?: string;
+}
+
+interface BreadcrumbsProps {
+  crumbs: Crumb[];
+  className?: string;
+}
+
+export default function Breadcrumbs({ crumbs, className = '' }: BreadcrumbsProps) {
+  if (!crumbs || crumbs.length === 0) return null;
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={`text-sm text-zinc-500 ${className}`}
+    >
+      <ol className="flex items-center flex-wrap gap-x-2 gap-y-1">
+        {crumbs.map((crumb, i) => {
+          const isLast = i === crumbs.length - 1;
+          return (
+            <li key={`${crumb.name}-${i}`} className="flex items-center gap-2">
+              {crumb.href && !isLast ? (
+                <Link
+                  href={crumb.href}
+                  className="hover:text-white transition-colors"
+                >
+                  {crumb.name}
+                </Link>
+              ) : (
+                <span
+                  aria-current={isLast ? 'page' : undefined}
+                  className={isLast ? 'text-zinc-300 truncate max-w-[70vw] sm:max-w-[420px]' : ''}
+                >
+                  {crumb.name}
+                </span>
+              )}
+              {!isLast && <span className="text-zinc-600" aria-hidden>›</span>}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/web/src/components/RelatedNovels.tsx
+++ b/web/src/components/RelatedNovels.tsx
@@ -1,0 +1,52 @@
+import Link from 'next/link';
+
+interface RelatedNovelItem {
+  slug: string;
+  title: string;
+  volume?: number;
+  chapter?: number;
+}
+
+interface Props {
+  items: RelatedNovelItem[];
+  locale: string;
+  seriesName?: string;
+}
+
+export default function RelatedNovels({ items, locale, seriesName }: Props) {
+  if (items.length === 0) return null;
+
+  const isKo = locale === 'ko';
+
+  return (
+    <div className="mt-10 p-5 bg-zinc-900 border border-zinc-800 rounded-xl">
+      <h3 className="text-base font-semibold text-white mb-4">
+        {isKo
+          ? `📖 ${seriesName ? `${seriesName} ` : ''}다른 화`
+          : `📖 More from ${seriesName ?? 'this series'}`}
+      </h3>
+      <div className="space-y-3">
+        {items.map((n) => (
+          <Link
+            key={n.slug}
+            href={`/novels/${n.slug}?lang=${locale}`}
+            className="block group"
+          >
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="text-zinc-300 group-hover:text-purple-400 transition-colors text-sm font-medium truncate">
+                &ldquo;{n.title}&rdquo;
+              </span>
+              {n.volume && n.chapter && (
+                <span className="text-xs text-zinc-500 flex-shrink-0 whitespace-nowrap">
+                  {isKo
+                    ? `${n.volume}권 ${n.chapter}화`
+                    : `Vol.${n.volume} Ch.${n.chapter}`}
+                </span>
+              )}
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/RelatedResearch.tsx
+++ b/web/src/components/RelatedResearch.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link';
+
+interface RelatedResearchItem {
+  slug: string;
+  title: string;
+  creator: string;
+  date: string;
+}
+
+interface Props {
+  items: RelatedResearchItem[];
+  locale: string;
+}
+
+export default function RelatedResearch({ items, locale }: Props) {
+  if (items.length === 0) return null;
+
+  const isKo = locale === 'ko';
+
+  return (
+    <div className="mt-10 p-5 bg-zinc-900 border border-zinc-800 rounded-xl">
+      <h3 className="text-base font-semibold text-white mb-4">
+        {isKo ? '🔬 관련 리서치' : '🔬 Related research'}
+      </h3>
+      <div className="space-y-3">
+        {items.map((r) => (
+          <Link
+            key={r.slug}
+            href={`/research/${r.slug}?lang=${locale}`}
+            className="block group"
+          >
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="text-zinc-300 group-hover:text-cyan-400 transition-colors text-sm font-medium truncate">
+                &ldquo;{r.title}&rdquo;
+              </span>
+              <span className="text-xs text-zinc-500 flex-shrink-0 whitespace-nowrap">
+                {r.date}
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/columns.ts
+++ b/web/src/lib/columns.ts
@@ -12,6 +12,7 @@ export interface ColumnFrontmatter {
   title: string;
   creator: string;
   date: string;
+  updated?: string;
   category: string;
   tags: string[];
   slug: string;
@@ -20,6 +21,13 @@ export interface ColumnFrontmatter {
   creatorImage?: string;
   citations?: Citation[];
   references?: string[];
+  articleType?: 'scholarly' | 'news' | 'opinion';
+  howto?: {
+    name: string;
+    description?: string;
+    totalTime?: string;
+    steps: { name: string; text: string; url?: string }[];
+  };
 }
 
 export interface Column {

--- a/web/src/lib/jsonld.ts
+++ b/web/src/lib/jsonld.ts
@@ -37,11 +37,7 @@ export function generateWebSiteJsonLd() {
       name: ORG_NAME,
       url: SITE_URL,
     },
-    potentialAction: {
-      '@type': 'SearchAction',
-      target: `${SITE_URL}/search?q={search_term_string}`,
-      'query-input': 'required name=search_term_string',
-    },
+    // TODO: /search 라우트 구현 시 SearchAction 복구 (현재는 엔드포인트 없음)
   };
 }
 
@@ -63,12 +59,16 @@ export function generateArticleJsonLd(column: { frontmatter: ColumnFrontmatter; 
     }
   }
 
+  const schemaType = fm.articleType === 'news' ? 'NewsArticle' : 'ScholarlyArticle';
+
   return {
     '@context': { '@vocab': 'https://schema.org/', '@language': lang },
-    '@type': 'ScholarlyArticle',
+    '@type': schemaType,
     headline: fm.title,
     description: fm.excerpt,
     datePublished: fm.date,
+    ...(fm.updated ? { dateModified: fm.updated } : {}),
+    ...(fm.articleType === 'news' && fm.category ? { articleSection: fm.category } : {}),
     inLanguage: lang,
     url,
     mainEntityOfPage: { '@type': 'WebPage', '@id': url },
@@ -165,6 +165,7 @@ export function generateResearchArticleJsonLd(
     headline: fm.title,
     description: fm.excerpt,
     datePublished: fm.date,
+    ...(fm.updated ? { dateModified: fm.updated } : {}),
     inLanguage: lang,
     url,
     mainEntityOfPage: { '@type': 'WebPage', '@id': url },
@@ -242,6 +243,63 @@ export function generateFAQJsonLd(faqs: { question: string; answer: string }[]) 
         text: faq.answer,
       },
     })),
+  };
+}
+
+// ─── HowTo ─────────────────────────────────────────────
+export interface HowToSpec {
+  name: string;
+  description?: string;
+  totalTime?: string; // ISO 8601 duration, e.g. "PT30M"
+  steps: { name: string; text: string; url?: string }[];
+}
+
+export function generateHowToJsonLd(spec: HowToSpec) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'HowTo',
+    name: spec.name,
+    ...(spec.description ? { description: spec.description } : {}),
+    ...(spec.totalTime ? { totalTime: spec.totalTime } : {}),
+    step: spec.steps.map((s, i) => ({
+      '@type': 'HowToStep',
+      position: i + 1,
+      name: s.name,
+      text: s.text,
+      ...(s.url ? { url: s.url } : {}),
+    })),
+  };
+}
+
+// ─── QAPage ────────────────────────────────────────────
+export interface QAPair {
+  question: string;
+  answer: string;
+  answerAuthor?: string;
+  upvoteCount?: number;
+}
+
+export function generateQAPageJsonLd(primary: QAPair, url: string) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'QAPage',
+    mainEntity: {
+      '@type': 'Question',
+      name: primary.question,
+      text: primary.question,
+      url,
+      answerCount: 1,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: primary.answer,
+        ...(primary.answerAuthor
+          ? { author: { '@type': 'Person', name: primary.answerAuthor } }
+          : {}),
+        ...(primary.upvoteCount !== undefined
+          ? { upvoteCount: primary.upvoteCount }
+          : {}),
+      },
+    },
   };
 }
 

--- a/web/src/lib/remarkGlossaryLinks.ts
+++ b/web/src/lib/remarkGlossaryLinks.ts
@@ -1,0 +1,118 @@
+import { glossaryTerms } from './glossary';
+
+interface MdastNode {
+  type: string;
+  value?: string;
+  children?: MdastNode[];
+  url?: string;
+}
+
+const SKIP_PARENT_TYPES = new Set(['link', 'linkReference', 'code', 'inlineCode', 'heading']);
+
+function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function hasKoreanChar(input: string): boolean {
+  return /[\uAC00-\uD7AF\u1100-\u11FF\u3130-\u318F]/.test(input);
+}
+
+function buildPatterns() {
+  return glossaryTerms.flatMap((g) => {
+    const patterns: { regex: RegExp; slug: string }[] = [];
+    if (g.term) {
+      patterns.push({
+        regex: new RegExp(`\\b(${escapeRegex(g.term)})\\b`, 'i'),
+        slug: g.slug,
+      });
+    }
+    if (g.termKo) {
+      const escaped = escapeRegex(g.termKo);
+      patterns.push({
+        regex: hasKoreanChar(g.termKo)
+          ? new RegExp(`(${escaped})`)
+          : new RegExp(`\\b(${escaped})\\b`, 'i'),
+        slug: g.slug,
+      });
+    }
+    return patterns;
+  });
+}
+
+export default function remarkGlossaryLinks() {
+  const patterns = buildPatterns();
+
+  return (tree: MdastNode) => {
+    const linkedSlugs = new Set<string>();
+
+    function walk(node: MdastNode, parentType: string | null) {
+      if (!node || !node.children) return;
+      const next: MdastNode[] = [];
+
+      for (const child of node.children) {
+        if (SKIP_PARENT_TYPES.has(child.type) || SKIP_PARENT_TYPES.has(parentType || '')) {
+          if (child.children) walk(child, child.type);
+          next.push(child);
+          continue;
+        }
+
+        if (child.type === 'text' && typeof child.value === 'string') {
+          const replacements = replaceFirstMatch(child.value, patterns, linkedSlugs);
+          if (replacements) {
+            next.push(...replacements);
+          } else {
+            next.push(child);
+          }
+        } else {
+          if (child.children) walk(child, child.type);
+          next.push(child);
+        }
+      }
+
+      node.children = next;
+    }
+
+    walk(tree, null);
+  };
+}
+
+function replaceFirstMatch(
+  text: string,
+  patterns: { regex: RegExp; slug: string }[],
+  linkedSlugs: Set<string>,
+): MdastNode[] | null {
+  let earliest: { idx: number; match: string; slug: string } | null = null;
+
+  for (const { regex, slug } of patterns) {
+    if (linkedSlugs.has(slug)) continue;
+    const m = regex.exec(text);
+    if (!m) continue;
+    if (earliest === null || m.index < earliest.idx) {
+      earliest = { idx: m.index, match: m[0], slug };
+    }
+  }
+
+  if (!earliest) return null;
+
+  linkedSlugs.add(earliest.slug);
+
+  const before = text.slice(0, earliest.idx);
+  const after = text.slice(earliest.idx + earliest.match.length);
+
+  const nodes: MdastNode[] = [];
+  if (before) nodes.push({ type: 'text', value: before });
+  nodes.push({
+    type: 'link',
+    url: `/glossary#${earliest.slug}`,
+    children: [{ type: 'text', value: earliest.match }],
+  });
+  if (after) {
+    const tail = replaceFirstMatch(after, patterns, linkedSlugs);
+    if (tail) {
+      nodes.push(...tail);
+    } else {
+      nodes.push({ type: 'text', value: after });
+    }
+  }
+  return nodes;
+}

--- a/web/src/lib/research.ts
+++ b/web/src/lib/research.ts
@@ -5,6 +5,7 @@ export interface ResearchFrontmatter {
   title: string;
   creator: string;
   date: string;
+  updated?: string;
   category: string;
   tags: string[];
   slug: string;

--- a/web/tests/e2e/hreflang.spec.ts
+++ b/web/tests/e2e/hreflang.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+
+const SITE_URL = 'https://hypeproof-ai.xyz';
+
+test.describe('hreflang / canonical consistency', () => {
+  test('home has canonical and alternate RSS link @desktop', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    const canonical = await page.locator('link[rel="canonical"]').getAttribute('href');
+    expect(canonical).toBeTruthy();
+    expect(canonical).toContain('hypeproof-ai.xyz');
+  });
+
+  test('column detail exposes ko/en/x-default hreflang @desktop', async ({ page }) => {
+    await page.goto('/columns', { waitUntil: 'domcontentloaded' });
+    await page.locator('a[href*="/columns/"]').first().click();
+    await page.waitForLoadState('domcontentloaded');
+
+    const langs = await page.locator('link[rel="alternate"][hreflang]').evaluateAll(
+      (nodes) => nodes.map((n) => (n as HTMLLinkElement).hreflang)
+    );
+    // Must at least have ko or en plus x-default
+    expect(langs).toContain('x-default');
+    expect(langs.some((l) => l === 'ko' || l === 'en')).toBe(true);
+  });
+
+  test('column detail canonical is free of ?lang= query @desktop', async ({ page }) => {
+    await page.goto('/columns', { waitUntil: 'domcontentloaded' });
+    await page.locator('a[href*="/columns/"]').first().click();
+    await page.waitForLoadState('domcontentloaded');
+
+    const canonical = await page.locator('link[rel="canonical"]').getAttribute('href');
+    expect(canonical).toBeTruthy();
+    expect(canonical).not.toContain('?lang=');
+  });
+
+  test('research detail exposes hreflang alternates @desktop', async ({ page }) => {
+    const res = await page.goto('/research', { waitUntil: 'domcontentloaded' });
+    if (!res || res.status() >= 400) test.skip();
+    const link = page.locator('a[href*="/research/"]').first();
+    if ((await link.count()) === 0) test.skip();
+    await link.click();
+    await page.waitForLoadState('domcontentloaded');
+
+    const langs = await page.locator('link[rel="alternate"][hreflang]').evaluateAll(
+      (nodes) => nodes.map((n) => (n as HTMLLinkElement).hreflang)
+    );
+    expect(langs.length).toBeGreaterThan(0);
+  });
+
+  test('sitemap.xml includes xhtml:link alternate entries @desktop', async ({ request }) => {
+    const res = await request.get('/sitemap.xml');
+    expect(res.status()).toBe(200);
+    const xml = await res.text();
+    expect(xml).toContain('<urlset');
+    expect(xml).toMatch(/rel="alternate"|xhtml:link/);
+  });
+
+  test('naver-site-verification meta tag present @desktop', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    const content = await page
+      .locator('meta[name="naver-site-verification"]')
+      .getAttribute('content');
+    expect(content).toBeTruthy();
+    expect(content).not.toContain('PLACEHOLDER');
+  });
+
+  test('root layout has exactly one main#main @desktop', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    expect(await page.locator('main#main').count()).toBe(1);
+  });
+
+  test('SearchAction schema is removed from WebSite JSON-LD @desktop', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    const scripts = await page
+      .locator('script[type="application/ld+json"]')
+      .allTextContents();
+    const joined = scripts.join('\n');
+    expect(joined).not.toContain('SearchAction');
+    // Baseline: sanity that JSON-LD is still present
+    expect(joined).toContain('Organization');
+  });
+
+  test.skip('sitemap hreflang targets are self-consistent', async ({ request }) => {
+    // Placeholder for deeper cross-check; enable when path-based i18n is adopted
+    const res = await request.get('/sitemap.xml');
+    const xml = await res.text();
+    expect(xml).toContain(SITE_URL);
+  });
+});


### PR DESCRIPTION
## Summary

Two commits that land a full-stack SEO / AEO / GEO uplift across the web app, targeting both **Google** and **Naver** search visibility and **AI answer engines** (Perplexity, Claude, ChatGPT).

- Inject real **Google + Naver site verification tokens** (env-override ready; inline fallbacks for unauth'd local builds)
- Remove `robots.nocache` so SERP cache previews work
- Add `<main id="main">` to root layout + downgrade duplicate `<main>` in list pages (fixes SkipLink target)
- Remove stale `SearchAction` schema (no `/search` route exists)
- `HowTo` + `QAPage` + `NewsArticle` JSON-LD generators, switchable via `frontmatter.articleType` / `frontmatter.howto`
- Conditional `dateModified` from `frontmatter.updated` (no fake freshness)
- `llms.txt` expanded to full bilingual index + license + citation format for LLM crawlers
- Profile-style OG images for `/creators/[slug]` and `/novels/authors/[name]`
- `<Breadcrumbs>` UI on columns/research/novels detail pages (matches existing JSON-LD BreadcrumbList)
- `RelatedResearch` + `RelatedNovels` internal-link widgets (parallel to `RelatedColumns`)
- `remarkGlossaryLinks` plugin auto-links the first occurrence of each glossary term to `/glossary#slug`
- Sanitize schema permits GFM task-list checkboxes; task items get clean flex styling
- Extra Naver crawler UAs (`Naverbot`, `Yetibot`, `Cowbot`) in `robots.ts`
- New Playwright spec `tests/e2e/hreflang.spec.ts` locks hreflang / canonical / `main#main` / Naver-verification / SearchAction-removed invariants

## Test plan

- [x] `npm run build` clean (`.next` removed) — Compiled successfully, all routes incl. new OG endpoints
- [x] TypeScript strict — 0 errors
- [x] Lint — no new errors from touched files (pre-existing `any` warnings unchanged)
- [ ] After merge + Vercel deploy: verify `<meta name="google-site-verification">` and `<meta name="naver-site-verification">` tokens live
- [ ] Google Search Console — claim domain, submit `sitemap.xml`
- [ ] Naver Search Advisor — claim site, request web collection
- [ ] Rich Results Test on a few column/research URLs — BreadcrumbList + ScholarlyArticle + (where applicable) NewsArticle / HowTo
- [ ] Facebook / Twitter Card debuggers on `/creators/{slug}` and `/novels/authors/cipher` to confirm profile OG renders
- [ ] `curl https://hypeproof-ai.xyz/llms.txt` — full bilingual index present

## Environment variables (optional, Vercel)

- `GOOGLE_SITE_VERIFICATION` — overrides the inline fallback when set
- `NAVER_SITE_VERIFICATION` — overrides the inline fallback when set

## Risks / notes

- `?lang=ko|en` query-based i18n kept as-is; path-based migration is deferred (would require 301 redirects for all existing URLs and is out of scope).
- `HowTo` / `NewsArticle` are opt-in via frontmatter — no existing content's JSON-LD shape changes until authors set the field.
- Glossary auto-linking only replaces the **first occurrence** per page and skips code blocks / existing links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)