### PR TITLE
chore(seo): adopt nextjs-sitemap-robots-guide patterns

### DIFF
--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -1,57 +1,65 @@
-import { MetadataRoute } from 'next'
- 
+import type { MetadataRoute } from 'next'
+
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = 'https://hypeproof-ai.xyz'
-  
+  const isProd = process.env.NODE_ENV === 'production'
+  const siteUrl = process.env.SITE_URL || 'https://hypeproof-ai.xyz'
+
+  // ── Dev / preview: block everything to prevent staging URLs from
+  //    being indexed as duplicate content.
+  if (!isProd) {
+    return {
+      rules: { userAgent: '*', disallow: '/' },
+    }
+  }
+
+  // Paths that must never be crawled by anyone.
+  const blockedPaths = ['/private/', '/admin/', '/api/', '/_next/', '/static/']
+
   return {
     rules: [
+      // 1) General crawler baseline
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/private/', '/admin/', '/api/', '/_next/', '/static/'],
+        disallow: blockedPaths,
+        crawlDelay: 1,
       },
-      {
-        userAgent: 'GPTBot',
-        allow: '/',
-      },
-      {
-        userAgent: 'ClaudeBot',
-        allow: '/',
-      },
-      {
-        userAgent: 'PerplexityBot',
-        allow: '/',
-      },
-      {
-        userAgent: 'GoogleOther',
-        allow: '/',
-      },
-      {
-        userAgent: 'Applebot-Extended',
-        allow: '/',
-      },
-      {
-        userAgent: 'cohere-ai',
-        allow: '/',
-      },
-      {
-        userAgent: 'Yeti',
-        allow: '/',
-      },
-      {
-        userAgent: 'Yetibot',
-        allow: '/',
-      },
-      {
-        userAgent: 'Naverbot',
-        allow: '/',
-      },
-      {
-        userAgent: 'Cowbot',
-        allow: '/',
-      },
+
+      // 2) Major search engines — tuned crawl rate
+      { userAgent: 'Googlebot',       crawlDelay: 0 },
+      { userAgent: 'Googlebot-Image', allow: ['/logos/', '/members/', '/authors/', '/og-image.png'], crawlDelay: 0 },
+      { userAgent: 'Googlebot-News',  disallow: '/' }, // not a Google News publisher
+      { userAgent: 'GoogleOther',     allow: '/', disallow: blockedPaths },
+      { userAgent: 'Bingbot',         crawlDelay: 1 },
+      { userAgent: 'DuckDuckBot',     crawlDelay: 2 },
+
+      // 3) Naver — primary Korean search
+      { userAgent: 'Yeti',     crawlDelay: 1 },
+      { userAgent: 'Yetibot',  crawlDelay: 1 },
+      { userAgent: 'Naverbot', crawlDelay: 1 },
+      { userAgent: 'Cowbot',   crawlDelay: 1 },
+
+      // 4) AI training bots — disallow so HypeProof content is not
+      //    absorbed into base-model training corpora without permission.
+      { userAgent: 'GPTBot',             disallow: '/' }, // OpenAI training
+      { userAgent: 'ClaudeBot',          disallow: '/' }, // Anthropic training
+      { userAgent: 'anthropic-ai',       disallow: '/' }, // Anthropic bulk
+      { userAgent: 'Google-Extended',    disallow: '/' }, // Gemini training
+      { userAgent: 'CCBot',              disallow: '/' }, // Common Crawl
+      { userAgent: 'Bytespider',         disallow: '/' }, // ByteDance
+      { userAgent: 'Meta-ExternalAgent', disallow: '/' }, // Meta AI training
+      { userAgent: 'Applebot-Extended',  disallow: '/' }, // Apple AI training opt-out
+      { userAgent: 'cohere-ai',          disallow: '/' }, // Cohere training
+
+      // 5) AI citation bots — allow so HypeProof is citable in real-time
+      //    answers from ChatGPT / Claude / Perplexity search surfaces.
+      { userAgent: 'ChatGPT-User',     allow: '/', disallow: blockedPaths },
+      { userAgent: 'OAI-SearchBot',    allow: '/', disallow: blockedPaths },
+      { userAgent: 'Claude-SearchBot', allow: '/', disallow: blockedPaths },
+      { userAgent: 'Claude-User',      allow: '/', disallow: blockedPaths },
+      { userAgent: 'PerplexityBot',    allow: '/', disallow: blockedPaths },
     ],
-    sitemap: `${baseUrl}/sitemap.xml`,
-    host: baseUrl,
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
   }
 }

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,4 +1,4 @@
-import { MetadataRoute } from 'next'
+import type { MetadataRoute } from 'next'
 import { getAllColumns } from '@/lib/columns'
 import { getAllResearch } from '@/lib/research'
 import { getAllNovels } from '@/lib/novels'
@@ -25,72 +25,44 @@ function latestContentDate(dates: (string | undefined)[]): string {
 }
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://hypeproof-ai.xyz'
+  const siteUrl = process.env.SITE_URL || 'https://hypeproof-ai.xyz'
 
-  // We intentionally list only main routes. Individual columns / research /
-  // novels / creators are discovered via in-page internal links (list pages,
-  // Related* components, breadcrumbs, footer). This keeps the sitemap small,
-  // strictly XSD-compliant, and easy for Search Console to consume.
-  const columnDates = [
+  // Main routes only. Individual columns / research / novels / creators are
+  // discovered via in-page internal links (list pages, Related* components,
+  // breadcrumbs, footer). Keeps the sitemap small and strictly XSD-compliant.
+  const latestColumnDate = latestContentDate([
     ...getAllColumns('ko').map(c => c.frontmatter.date),
     ...getAllColumns('en').map(c => c.frontmatter.date),
-  ]
-  const researchDates = [
+  ])
+  const latestResearchDate = latestContentDate([
     ...getAllResearch('ko').map(r => r.frontmatter.date),
     ...getAllResearch('en').map(r => r.frontmatter.date),
-  ]
-  const novelDates = [
+  ])
+  const latestNovelDate = latestContentDate([
     ...getAllNovels('ko').map(n => n.frontmatter.date),
     ...getAllNovels('en').map(n => n.frontmatter.date),
-  ]
-
-  const latestColumnDate = latestContentDate(columnDates)
-  const latestResearchDate = latestContentDate(researchDates)
-  const latestNovelDate = latestContentDate(novelDates)
+  ])
   const latestAnyDate = latestContentDate([latestColumnDate, latestResearchDate, latestNovelDate])
 
-  return [
-    {
-      url: baseUrl,
-      lastModified: toDateString(latestAnyDate),
-      changeFrequency: 'daily',
-      priority: 1,
-    },
-    {
-      url: `${baseUrl}/columns`,
-      lastModified: toDateString(latestColumnDate),
-      changeFrequency: 'daily',
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/research`,
-      lastModified: toDateString(latestResearchDate),
-      changeFrequency: 'daily',
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/novels`,
-      lastModified: toDateString(latestNovelDate),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/creators`,
-      lastModified: toDateString(latestAnyDate),
-      changeFrequency: 'weekly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/glossary`,
-      lastModified: toDateString(latestAnyDate),
-      changeFrequency: 'weekly',
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/ai-personas`,
-      lastModified: toDateString(latestAnyDate),
-      changeFrequency: 'weekly',
-      priority: 0.5,
-    },
+  const staticRoutes: Array<{
+    path: string
+    lastModified: string
+    changeFrequency: MetadataRoute.Sitemap[number]['changeFrequency']
+    priority: number
+  }> = [
+    { path: '',              lastModified: latestAnyDate,      changeFrequency: 'daily',   priority: 1.0 },
+    { path: '/columns',      lastModified: latestColumnDate,   changeFrequency: 'daily',   priority: 0.9 },
+    { path: '/research',     lastModified: latestResearchDate, changeFrequency: 'daily',   priority: 0.9 },
+    { path: '/novels',       lastModified: latestNovelDate,    changeFrequency: 'weekly',  priority: 0.8 },
+    { path: '/creators',     lastModified: latestAnyDate,      changeFrequency: 'weekly',  priority: 0.7 },
+    { path: '/glossary',     lastModified: latestAnyDate,      changeFrequency: 'weekly',  priority: 0.6 },
+    { path: '/ai-personas',  lastModified: latestAnyDate,      changeFrequency: 'weekly',  priority: 0.5 },
   ]
+
+  return staticRoutes.map(r => ({
+    url: `${siteUrl}${r.path}`,
+    lastModified: toDateString(r.lastModified),
+    changeFrequency: r.changeFrequency,
+    priority: r.priority,
+  }))
 }


### PR DESCRIPTION
Apply the withdenden(dendenCare) Next.js 13+ App Router guide to our sitemap.ts and robots.ts for clarity, maintainability, and a contemporary AI-bot policy.

sitemap.ts
- SITE_URL env var with apex domain fallback
- staticRoutes[] array shape (path/lastModified/changeFrequency/priority rows) instead of inlined objects — drop-in editable
- Retains per-section latestContentDate anchoring (stricter than the guide's single new Date() — prevents spurious lastmod churn)
- Output is identical in shape to PR #28's minimal 7-route sitemap

robots.ts — substantive policy shift
- isProd guard: dev/preview environments block everything
- blockedPaths constant reused across rules
- Differentiated crawlers with tuned crawl delays:
  - Googlebot / Googlebot-Image / Googlebot-News / GoogleOther
  - Bingbot, DuckDuckBot
  - Naver: Yeti / Yetibot / Naverbot / Cowbot
- AI training bots now DISALLOWED (change from prior broad allow): GPTBot, ClaudeBot, anthropic-ai, Google-Extended, CCBot, Bytespider, Meta-ExternalAgent, Applebot-Extended, cohere-ai
- AI citation bots explicitly ALLOWED so HypeProof remains citable in real-time LLM answers: ChatGPT-User, OAI-SearchBot, Claude-SearchBot, Claude-User, PerplexityBot
- Googlebot-News disallowed (we're not a Google News publisher)
- Googlebot-Image scoped to actual image paths

Rationale: sophisticated middle ground — protects content IP from bulk training corpora absorption while keeping AI answer engine citation pathways open. Aligns with HypeProof's "prove, don't hype" brand stance.