### PR TITLE
fix(identity): HypeProof → HypeProof Lab 브랜딩 통일 (6곳)

### DIFF
--- a/web/src/app/identity/_i18n/content.ts
+++ b/web/src/app/identity/_i18n/content.ts
@@ -14,10 +14,10 @@ export function useIdentityLang(): Lang {
 // -----------------------------------------------------------------------------
 
 export const c = {
-  backHome: { ko: "HypeProof 홈으로", en: "Back to HypeProof" },
+  backHome: { ko: "HypeProof Lab 홈으로", en: "Back to HypeProof Lab" },
 
   // Hero
-  heroEyebrow: { ko: "HypeProof", en: "HypeProof" },
+  heroEyebrow: { ko: "HypeProof Lab", en: "HypeProof Lab" },
   heroTension: {
     ko: "이름을 붙이기도 전에 AI는 세상을 다시 쓰고, 우리가 옳은 길로 가고 있는지 누구도 말해주지 않습니다.",
     en: "AI rewrites the world before we can name it — and whether we're on the right path, no one can say.",
@@ -247,7 +247,7 @@ export const c = {
     label: { ko: "Voluntary", en: "Voluntary" },
     title: { ko: "구독자가 아니라 참가자", en: "Participants, not subscribers" },
     body: {
-      ko: "HypeProof 멤버는 스크롤하는 사람이 아닙니다. AI로 무언가를 직접 만들려는 사람입니다.",
+      ko: "HypeProof Lab 멤버는 스크롤하는 사람이 아닙니다. AI로 무언가를 직접 만들려는 사람입니다.",
       en: "Members don't scroll through. They come to make something with AI.",
     },
   },

--- a/web/src/app/identity/layout.tsx
+++ b/web/src/app/identity/layout.tsx
@@ -7,18 +7,18 @@ import { IdentityFooter } from "./_components/IdentityFooter";
 import "../kids-edu/kids-edu.css";
 
 export const metadata: Metadata = {
-  title: "HypeProof — AI 크리에이터가 모이는 곳",
+  title: "HypeProof Lab — AI 크리에이터가 모이는 곳",
   description:
     "AI 빌더·리서처·크리에이터가 모이는 곳. 기술이 아니라 창작에 집중합니다.",
   openGraph: {
-    title: "HypeProof — Where AI creators gather",
+    title: "HypeProof Lab — Where AI creators gather",
     description:
       "Where AI builders, researchers, and creators gather — focused on creation, not the tech itself.",
     type: "website",
   },
 };
 
-// HypeProof 브랜드 퍼플로 accent 재정의 (kids-edu의 Apple blue 대신).
+// HypeProof Lab 브랜드 퍼플로 accent 재정의 (kids-edu의 Apple blue 대신).
 const identityThemeVars: CSSProperties = {
   ["--kf-accent" as string]: "#a855f7",
   ["--kf-accent-hover" as string]: "#9333ea",


### PR DESCRIPTION
/identity 페이지의 UI 문구 6곳을 캐노니컬 표기인 "HypeProof Lab"으로 통일.

변경 위치:
- layout.tsx: meta title (KO), OG title (EN), 코드 주석
- _i18n/content.ts: backHome (ko/en), heroEyebrow (ko/en), Voluntary 섹션 본문 (ko)

원래 feat/migration-and-refactor 브랜치 0e503be에 묶여있던 변경 중 identity UI 부분만 분리해 별도 PR로 머지. 마이그레이션 코드 / RFC 문서 / 대시보드 HTML과 결합 해제.