### PR TITLE
feat(dashboard): 이벤트 sub-task 체크리스트 + 진척도 + @ 멤버 멘션 + cal-cli

### DIFF
--- a/skills/cal/SKILL.md
+++ b/skills/cal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cal
-description: HypeProof Lab 일정 등록·변경·취소·삭제 + Google Calendar 양방향 동기화. /cal 또는 자연어("일정 추가", "X 일정 바꿔", "Y 취소", "캘린더 동기화") 발동.
+description: HypeProof Lab 일정 + 이벤트 sub-task(체크리스트) 등록·변경·취소·삭제 + Google Calendar 양방향 동기화. /cal 또는 자연어("일정 추가", "X 일정 바꿔", "@TJ 할일 추가", "Y 취소", "캘린더 동기화") 발동.
 argument-hint: <자연어로 자유롭게>
 allowed-tools: Read, Edit, Bash, mcp__claude_ai_Google_Calendar__authenticate, mcp__claude_ai_Google_Calendar__complete_authentication
 ---
@@ -64,20 +64,110 @@ allowed-tools: Read, Edit, Bash, mcp__claude_ai_Google_Calendar__authenticate, m
 6. `gcalSync`: `delete_event(externalIds.gcal)` → externalIds.gcal 필드 함께 제거
 7. tsc 검증 → 결과 요약
 
+### TASK_ADD (이벤트 sub-task 등록)
+트리거: "@TJ 5/22까지 촬영 준비", "치과 파일럿에 동의서 양식 추가", `/cal task add ...`
+
+1. 자연어 파싱:
+   - `@displayName` → assignees (members.json의 displayName 매칭)
+   - 날짜 표현 (`5/22`, `2026-05-22`, `내일`, `다음 화요일`) → dueDate
+   - "긴급"/"high"/"urgent" → priority='high', "낮음"/"low" → priority='low'
+   - event 매칭: 발화 안에 이벤트 제목 키워드가 있으면 그 이벤트, 또는 가장 임박한 진행중 이벤트, 또는 unattached
+2. id 생성: `t-{Date.now()}-{rand}`
+3. **diff preview**: 신규 task 카드 (이벤트 제목, assignees, dueDate, priority)
+4. confirm
+5. store.addTask() — JsonFileStore일 땐 JSON write, SupabaseTimelineStore일 땐 timeline_tasks INSERT + timeline_task_log 'created'
+6. (선택) Discord webhook → assignees 멘션
+7. tsc 검증 → 결과 요약
+
+### TASK_DONE (체크)
+트리거: "촬영 준비 끝났어", "X 완료", `/cal task done <id 또는 키워드>`
+
+1. 키워드/id로 대상 식별. 모호 시 후보 나열 (open 상태만)
+2. 매칭된 task가 본인 reporter거나 assignees 포함이어야 (권한)
+3. store.toggleTaskDone(id, doneBy) — done=true, doneAt=now, doneBy=현재 사용자
+   → task_log 'done:true' 자동 기록
+4. 결과 요약 (이벤트 진척도 변화 포함: "치과 파일럿 진척도 2/5 → 3/5")
+
+### TASK_REMOVE
+트리거: "X 빼자", `/cal task remove <id>`
+
+1. 대상 식별 + 권한 (reporter만)
+2. confirm
+3. store.removeTask(id)
+
+### TASK_LIST (조회)
+트리거: "내 할 일", "@TJ 할 일", `/cal task list [@user]`
+
+1. 필터 조건 (assignee, event, openOnly, doneOnly)
+2. cal-cli 호출:
+   ```bash
+   node scripts/cal-cli.mjs task-list '{"assignee":"TJ","openOnly":true}'
+   ```
+3. 결과를 이벤트별 그룹화 후 markdown 출력
+4. dashboard URL 함께 출력 ("자세히는 /dashboard 캘린더 탭")
+
+### TASK_LIST 출력 포맷 (예시)
+
+```markdown
+## /cal task list — @TJ (open만)
+
+### 📅 치과 파일럿 (5/26) — 2/3 완료 🔥1
+- ☐ 촬영 준비물 정리           due 5/22 🔥 high
+- ☐ 현장 코디                  due 5/26
+- ☑ 레퍼런스 패키지 준비       (Jay 완료, 5/15)
+
+### 📅 보아치과 (4/29) — 1/1 완료 ✅
+- ☑ 가격 드래프트 제출         (Jay 완료, 5/10)
+
+### 🗂 Unattached — 0/1
+- ☐ 다음주 미팅 안건 정리      due 5/20
+
+전체: 본인 open 3건 / 진행중 이벤트 2개
+대시보드: https://hypeproof-ai.xyz/dashboard
+```
+
+상태 아이콘:
+- ☑ done · ☐ open · 🔥 overdue · ✅ all-done · ⚠ blocked
+
 ## 공통 작업 흐름
 
 ```
 (a) reconcile() 먼저 실행 — gcal 외부 변경 import → 로컬 갱신
-(b) Read data/project-timeline.json — 최신 상태 로드
+(b) cal-cli read — 최신 상태 로드 (env 분기 자동: JSON or Supabase)
 (c) 자연어 의도 파싱 → action 분류 → 대상 식별 → diff 생성
 (d) diff preview를 사용자에게 보여주고 confirm 대기
+    - dry-run으로 미리 결과 보여줄 수 있음 (--dry-run flag)
     - delete는 두 번 confirm
     - cancel/delete 모호하면 "취소(이력 보존)인가요, 삭제(완전 제거)인가요?" 되묻기
-(e) Edit 도구로 JSON 갱신
+(e) cal-cli <action> — 단일 CLI로 write (JSON 직접 편집 금지)
 (f) gcalSync.push(action, payload) — 인증 미완료 시 OAuth 안내 후 push 보류
 (g) cd web && npx tsc --noEmit (빠른 검증, full build는 deploy 시점)
 (h) 결과 요약 (외부 변경 import 건수 + 액션 종류 + 변경 항목 + gcal sync 상태)
 ```
+
+### cal-cli 사용 (중요)
+
+**JSON 직접 Edit 금지**. 모든 write는 `web/scripts/cal-cli.mjs` 통해서. 이유:
+- env(TIMELINE_STORE)에 따라 JSON vs Supabase 자동 분기
+- audit log 자동 기록 (task_log)
+- due 자동 default (event date - 3일)
+- stdout에 JSON 1줄로 결과 반환 → bash에서 jq로 파싱 용이
+
+```bash
+# repo root 또는 web/ 에서 실행
+cd web && node --env-file=.env.development.local scripts/cal-cli.mjs <cmd> [args] [--dry-run]
+
+# 예시
+node scripts/cal-cli.mjs read
+node scripts/cal-cli.mjs event-add '{"id":"ev-x","lane":"direct","title":"새 미팅","date":{"kind":"date","iso":"2026-05-30"},"status":"planned"}'
+node scripts/cal-cli.mjs event-cancel ev-donga-cancer "동아 측 일정 변경"
+node scripts/cal-cli.mjs task-add '{"eventId":"ev-dental-pilot","title":"촬영 준비물 정리","assignees":["TJ"],"dueDate":"2026-05-22","reporter":"tlswpgud22@nate.com"}'
+node scripts/cal-cli.mjs task-add '{"eventId":"ev-dental-pilot","title":"현장 코디","assignees":["Ryan"]}' --dry-run
+node scripts/cal-cli.mjs task-done t-1747... shin_bro
+node scripts/cal-cli.mjs task-list '{"assignee":"TJ","openOnly":true}'
+```
+
+`--dry-run` 옵션: 파일/DB write 없이 어떤 변경이 일어날지 stdout으로 미리 보기. confirm 단계에서 활용.
 
 ## Google Calendar 양방향 동기화
 
@@ -89,13 +179,29 @@ allowed-tools: Read, Edit, Bash, mcp__claude_ai_Google_Calendar__authenticate, m
   3. `mcp__claude_ai_Google_Calendar__complete_authentication(callback_url)` 호출
   4. 인증 완료 후 이벤트 CRUD tool 활성화 — 그 다음 호출에서 사용 가능
 
+### Deferred tool 로딩 (인증 후 필수)
+인증 직후 시점엔 `authenticate` / `complete_authentication`만 schema가 노출되어 있음.
+**실제 push/pull에 쓰는 `create_event` / `update_event` / `delete_event` / `list_events`는 deferred tools**.
+호출 전에 ToolSearch로 schema 가져와야 함:
+
+```
+ToolSearch(query: "google calendar event", max_results: 6)
+   → returns <functions> definitions for:
+       mcp__claude_ai_Google_Calendar__create_event
+       mcp__claude_ai_Google_Calendar__update_event
+       mcp__claude_ai_Google_Calendar__delete_event
+       mcp__claude_ai_Google_Calendar__list_events
+```
+
+이후 그 도구들이 일반 호출 가능. 인증 안 됐으면 ToolSearch 결과에 안 나오니 OAuth 흐름부터.
+
 ### calendarId 결정
 - 첫 sync에서 사용자에게 "Google Calendar의 어떤 캘린더에 연결? (primary 권장)" 묻기
 - 결정된 ID를 `data.gcal.calendarId`에 저장 → 이후 자동 사용
 
 ### Push 매핑 (로컬 → gcal)
-- summary: `[{lane label}] {title}` (예: `[Filamentree] 바이오팜`)
-  - month/quarter는 prefix 추가: `(월간 미정) [Filamentree] 동아일보` / `(분기 후속) [HypeProof] 세일즈 자산화`
+- summary: `[{lane label}] {title}` (예: `[비트리 channel] 바이오팜`)
+  - month/quarter는 prefix 추가: `(월간 미정) [비트리 channel] 동아일보` / `(분기 후속) [HypeProof] 세일즈 자산화`
 - description: subtitle / 담당 / 연락처 / 메모를 줄바꿈으로 합침
 - start/end:
   - `date` (partOfDay 'AM') → `T09:00–T12:00 +09:00`
@@ -144,7 +250,10 @@ FuzzyDate 표기 규약:
 
 - 항상 `web/src/lib/timeline/store.ts`의 `defaultStore()`만 사용
 - JSON 직접 sed 편집 금지 (구조 깨짐)
-- 추후 Supabase 이전 시 `JsonFileStore`만 `SupabaseStore`로 갈아끼우면 됨 → 본 skill 코드 변경 불필요
+- **env 분기**:
+  - `TIMELINE_STORE=supabase` → `SupabaseTimelineStore` (`timeline_events` / `timeline_tasks` / `timeline_task_log` 등)
+  - 미설정 → `JsonFileStore` (`web/data/project-timeline.json`)
+- Supabase로 전환 후엔 본 skill의 흐름·코드 변경 0. store 메서드 시그니처 동일.
 
 ## 출력 포맷 (예시)
 
@@ -172,12 +281,13 @@ FuzzyDate 표기 규약:
 
 ## 금지 사항
 
-- **`sed`로 JSON 수정 금지** — 구조 깨짐, 항상 Read + Edit (또는 Write로 전체)
+- **JSON 직접 편집 금지** — `web/data/project-timeline.json`을 sed/Edit으로 직접 수정 X. 반드시 `cal-cli.mjs` 통해서.
 - **`academy-timeline.json` 건드리지 말 것** — 별도 5/5 D-Day Gantt 데이터, 본 skill 범위 밖
 - **cancel을 delete로 처리 금지** — 이력 손실
 - **git push 자동 금지** — memory rule, 사용자 명시 요청 시에만
 - **모호한 발화에 발동 금지** — 키워드+액션 의도가 명확하지 않으면 무반응
-- **gcal에 직접 이벤트 만들지 말 것** — 항상 로컬 JSON이 source of truth, gcal은 mirror
+- **gcal에 직접 이벤트 만들지 말 것** — 항상 로컬/Supabase가 source of truth, gcal은 mirror
+- **권한 무시 금지** — task done은 reporter 또는 assignee만, task remove는 reporter만
 
 ## 학습 사고 사례
 

--- a/skills/cal/schema.md
+++ b/skills/cal/schema.md
@@ -46,7 +46,7 @@ type Lane = 'direct' | 'channel' | 'reusable';
 ```
 
 - `direct` — HypeProof Direct (자사 직접 채널, 보라색)
-- `channel` — Filamentree Channel (파트너 채널, 녹색)
+- `channel` — 비트리 channel (前 Filamentree, 비트리코퍼레이션 산하 파트너 채널, 녹색)
 - `reusable` — Reusable Asset Layer (날짜 없는 자산, 회색)
 
 `reusable` lane은 보통 `events`가 아니라 `reusableAssets[]`에 들어감. events에 reusable이 들어가는 경우는 `kind: 'ongoing'`만 허용.
@@ -133,7 +133,7 @@ severity별 색:
 ```ts
 interface TimelineLanesMeta {
   direct: { label: 'HypeProof Direct'; color: '#a78bfa' };
-  channel: { label: 'Filamentree Channel'; color: '#34d399' };
+  channel: { label: '비트리 channel'; color: '#34d399' };
   reusable: { label: 'Reusable Asset Layer'; color: '#94a3b8' };
 }
 ```

--- a/web/data/project-timeline.json
+++ b/web/data/project-timeline.json
@@ -1,17 +1,19 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-30T17:00:00+09:00",
-  "title": "HypeProof Current Project Timeline Map",
-  "subtitle": "계속 바뀌는 행보를 팀이 헷갈리지 않도록, 채널·고객·일정·산출물 기준으로 정리한 한 장",
-  "priorityBanner": {
-    "headline": "현재 우선순위 변경",
-    "body": "국립암센터 5/5 강의는 6월로 연기 → 5/5 기준 산출물은 Wrap-up → 치과 5/26과 바이오팜 제안 준비로 전환",
-    "severity": "pivot"
-  },
+  "updatedAt": "2026-05-11T00:59:11.513Z",
   "lanes": {
-    "direct": { "label": "HypeProof Direct", "color": "#a78bfa" },
-    "channel": { "label": "Filamentree Channel", "color": "#34d399" },
-    "reusable": { "label": "Reusable Asset Layer", "color": "#94a3b8" }
+    "direct": {
+      "label": "HypeProof Direct",
+      "color": "#a78bfa"
+    },
+    "channel": {
+      "label": "비트리 channel",
+      "color": "#34d399"
+    },
+    "reusable": {
+      "label": "Reusable Asset Layer",
+      "color": "#94a3b8"
+    }
   },
   "events": [
     {
@@ -19,27 +21,46 @@
       "lane": "direct",
       "title": "보아치과",
       "subtitle": "전문직 교육",
-      "date": { "kind": "date", "iso": "2026-04-29" },
+      "date": {
+        "kind": "date",
+        "iso": "2026-04-29"
+      },
       "status": "planned",
-      "contacts": ["Jay 컨택트"],
-      "notes": ["5/26 확정 방향, 참석자 정리"]
+      "contacts": [
+        "Jay 컨택트"
+      ],
+      "notes": [
+        "5/26 확정 방향, 참석자 정리"
+      ]
     },
     {
       "id": "ev-biofarm",
       "lane": "channel",
       "title": "바이오팜",
       "subtitle": "Parents / Kids 교육",
-      "date": { "kind": "date", "iso": "2026-04-29" },
+      "date": {
+        "kind": "date",
+        "iso": "2026-04-29"
+      },
       "status": "planned",
-      "contacts": ["오성은 팀장", "남완호 본부장"],
-      "notes": ["SANS 언급 금지"]
+      "contacts": [
+        "오성은 팀장",
+        "남완호 본부장"
+      ],
+      "notes": [
+        "SANS 언급 금지"
+      ]
     },
     {
       "id": "ev-0430-submit",
       "lane": "channel",
       "title": "4/30 오전 제출",
       "subtitle": "커리큘럼 + 강사 프로필 슬라이드",
-      "date": { "kind": "date", "iso": "2026-04-30", "partOfDay": "AM" },
+      "date": {
+        "kind": "date",
+        "iso": "2026-04-30",
+        "partOfDay": "AM"
+      },
       "status": "planned",
       "owner": "TJ",
       "notes": [
@@ -52,17 +73,26 @@
       "lane": "direct",
       "title": "치과 파일럿 실행",
       "subtitle": "간결한 강의 + 촬영 활용",
-      "date": { "kind": "date", "iso": "2026-05-26" },
+      "date": {
+        "kind": "date",
+        "iso": "2026-05-26"
+      },
       "status": "planned",
       "owner": "TJ",
-      "notes": ["TJ: 레퍼런스 패키지 준비"]
+      "notes": [
+        "TJ: 레퍼런스 패키지 준비"
+      ]
     },
     {
       "id": "ev-donga-cancer",
       "lane": "channel",
       "title": "동아일보 / 국립암센터",
       "subtitle": "소아암 교육 / 6월로 연기",
-      "date": { "kind": "month", "year": 2026, "month": 6 },
+      "date": {
+        "kind": "month",
+        "year": 2026,
+        "month": 6
+      },
       "status": "deferred",
       "notes": [
         "5/5 준비물은 폐기하지 않음",
@@ -74,19 +104,33 @@
       "lane": "direct",
       "title": "세일즈 자산화",
       "subtitle": "영상 / 사례 / 1페이지 요약",
-      "date": { "kind": "quarter", "year": 2026, "quarter": 2 },
+      "date": {
+        "kind": "quarter",
+        "year": 2026,
+        "quarter": 2
+      },
       "status": "planned",
-      "notes": ["다음 유료 고객으로 연결"]
+      "notes": [
+        "다음 유료 고객으로 연결"
+      ]
     },
     {
       "id": "ev-hpl-meeting-0505",
       "lane": "direct",
       "title": "HypeProof Lab 모임",
       "subtitle": "어린이날",
-      "date": { "kind": "date", "iso": "2026-05-05", "partOfDay": "PM" },
+      "date": {
+        "kind": "date",
+        "iso": "2026-05-05",
+        "partOfDay": "PM"
+      },
       "status": "planned",
-      "contacts": ["참석자 전원"],
-      "notes": ["시간: 오후 5시"]
+      "contacts": [
+        "참석자 전원"
+      ],
+      "notes": [
+        "시간: 오후 5시"
+      ]
     }
   ],
   "reusableAssets": [
@@ -116,5 +160,13 @@
       "ownedBy": "Jay"
     }
   ],
+  "tasks": [],
+  "title": "HypeProof Current Project Timeline Map",
+  "subtitle": "계속 바뀌는 행보를 팀이 헷갈리지 않도록, 채널·고객·일정·산출물 기준으로 정리한 한 장",
+  "priorityBanner": {
+    "headline": "현재 우선순위 변경",
+    "body": "국립암센터 5/5 강의는 6월로 연기 → 5/5 기준 산출물은 Wrap-up → 치과 5/26과 바이오팜 제안 준비로 전환",
+    "severity": "pivot"
+  },
   "gcal": {}
 }

--- a/web/scripts/cal-cli.mjs
+++ b/web/scripts/cal-cli.mjs
@@ -1,0 +1,430 @@
+#!/usr/bin/env node
+// /cal skill의 단일 진입점.
+// JSON 파일 모드 / Supabase 모드를 env(TIMELINE_STORE)로 자동 분기.
+// 명령 단위로 호출, --dry-run 지원, stdout에 JSON 결과 1줄.
+//
+// 사용:
+//   node --env-file=.env.development.local scripts/cal-cli.mjs <cmd> [json-payload] [--dry-run]
+//
+// 명령:
+//   read                                     → 전체 TimelineData JSON 출력
+//   event-add      <json>                    이벤트 추가
+//   event-update   <id> <json>               이벤트 변경
+//   event-cancel   <id> [reason]             상태 cancelled (이력 보존)
+//   event-remove   <id>                      완전 삭제
+//   asset-add      <json>                    재사용 자산 추가
+//   asset-remove   <id>
+//   task-add       <json>                    sub-task 추가 (eventId 있으면 due 자동 default = event date - 3일)
+//   task-update    <id> <json>
+//   task-done      <id> [doneBy]
+//   task-undone    <id>
+//   task-remove    <id>
+//   task-list      [filter-json]             {eventId?, assignee?, doneOnly?, openOnly?}
+//   set-banner     <json|null>
+//
+// JSON payload는 TimelineEvent / SubTask / ReusableAsset 스키마.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [, , cmd, ...rest] = process.argv;
+const dryRun = process.argv.includes('--dry-run');
+const args = rest.filter(a => a !== '--dry-run');
+
+function out(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+function fail(msg, extra = {}) {
+  out({ ok: false, error: msg, ...extra });
+  process.exit(1);
+}
+
+function parseJson(s, label) {
+  try { return JSON.parse(s); }
+  catch (e) { fail(`Invalid JSON for ${label}: ${e.message}`); }
+}
+
+// ─── Storage adapters ─────────────────────────────────────
+const MODE = process.env.TIMELINE_STORE === 'supabase' ? 'supabase' : 'json';
+
+const JSON_PATHS = [
+  path.join(process.cwd(), 'data', 'project-timeline.json'),
+  path.join(process.cwd(), 'web', 'data', 'project-timeline.json'),
+  path.join(process.cwd(), '..', 'data', 'project-timeline.json'),
+];
+
+function resolveJsonPath() {
+  for (const p of JSON_PATHS) if (fs.existsSync(p)) return p;
+  return JSON_PATHS[0];
+}
+
+function jsonRead() {
+  try { return JSON.parse(fs.readFileSync(resolveJsonPath(), 'utf-8')); }
+  catch { return { version: 1, updatedAt: '', lanes: {}, events: [], reusableAssets: [], tasks: [], taskLog: [] }; }
+}
+function jsonWrite(data) {
+  const next = { ...data, updatedAt: new Date().toISOString() };
+  const filePath = resolveJsonPath();
+  const tmp = `${filePath}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(next, null, 2) + '\n', 'utf-8');
+  fs.renameSync(tmp, filePath);
+  return next;
+}
+
+async function supa() {
+  const { createClient } = await import('@supabase/supabase-js');
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) fail('Supabase 모드인데 env 미설정 (SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)');
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+// ─── helpers ───────────────────────────────────────────────
+function newId(prefix) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function appendLog(data, entry) {
+  data.taskLog = [
+    ...(data.taskLog ?? []),
+    { id: newId('log'), createdAt: new Date().toISOString(), ...entry },
+  ];
+}
+
+function subtractDays(iso, n) {
+  const [y, m, d] = iso.split('-').map(Number);
+  const t = new Date(Date.UTC(y, m - 1, d - n));
+  return t.toISOString().slice(0, 10);
+}
+
+function applyDueDefault(task, events) {
+  if (task.dueDate || !task.eventId) return task;
+  const ev = events.find(e => e.id === task.eventId);
+  if (!ev) return task;
+  if (ev.date?.kind === 'date' && ev.date.iso) {
+    return { ...task, dueDate: subtractDays(ev.date.iso, 3) };
+  }
+  return task;
+}
+
+// ─── Command handlers (JSON mode) ─────────────────────────
+async function handleJson() {
+  const data = jsonRead();
+
+  switch (cmd) {
+    case 'read':
+      out(data);
+      return;
+
+    case 'event-add': {
+      const ev = parseJson(args[0] ?? '', 'event');
+      if (!ev?.id || !ev?.title || !ev?.lane) fail('event needs {id,lane,title,date,status}');
+      if (data.events.some(e => e.id === ev.id)) {
+        out({ ok: false, error: `event ${ev.id} already exists` });
+        return;
+      }
+      const next = { ...data, events: [...data.events, ev] };
+      if (!dryRun) jsonWrite(next);
+      out({ ok: true, mode: MODE, dryRun, action: 'event-add', event: ev });
+      return;
+    }
+
+    case 'event-update': {
+      const id = args[0];
+      const patch = parseJson(args[1] ?? '{}', 'patch');
+      const idx = data.events.findIndex(e => e.id === id);
+      if (idx < 0) fail(`event ${id} not found`);
+      const before = data.events[idx];
+      const after = { ...before, ...patch, id };
+      const events = [...data.events];
+      events[idx] = after;
+      if (!dryRun) jsonWrite({ ...data, events });
+      out({ ok: true, mode: MODE, dryRun, action: 'event-update', before, after });
+      return;
+    }
+
+    case 'event-cancel': {
+      const id = args[0];
+      const reason = args[1];
+      const idx = data.events.findIndex(e => e.id === id);
+      if (idx < 0) fail(`event ${id} not found`);
+      const after = {
+        ...data.events[idx],
+        status: 'cancelled',
+        cancelledAt: new Date().toISOString(),
+        cancelReason: reason ?? undefined,
+      };
+      const events = [...data.events];
+      events[idx] = after;
+      if (!dryRun) jsonWrite({ ...data, events });
+      out({ ok: true, mode: MODE, dryRun, action: 'event-cancel', after });
+      return;
+    }
+
+    case 'event-remove': {
+      const id = args[0];
+      const before = data.events.find(e => e.id === id);
+      if (!before) fail(`event ${id} not found`);
+      if (!dryRun) jsonWrite({ ...data, events: data.events.filter(e => e.id !== id) });
+      out({ ok: true, mode: MODE, dryRun, action: 'event-remove', removed: before });
+      return;
+    }
+
+    case 'task-add': {
+      const t = parseJson(args[0] ?? '', 'task');
+      if (!t?.title) fail('task needs {title, assignees, eventId?, dueDate?, priority?}');
+      const fullTask = applyDueDefault(
+        {
+          id: t.id ?? newId('t'),
+          eventId: t.eventId,
+          title: t.title,
+          assignees: t.assignees ?? [],
+          reporter: t.reporter,
+          dueDate: t.dueDate,
+          priority: t.priority ?? 'med',
+          done: false,
+          sourceExcerpt: t.sourceExcerpt,
+          createdAt: new Date().toISOString(),
+        },
+        data.events,
+      );
+      const next = { ...data, tasks: [...(data.tasks ?? []), fullTask] };
+      appendLog(next, {
+        taskId: fullTask.id,
+        actor: fullTask.reporter ?? 'cli',
+        action: 'created',
+        after: fullTask,
+      });
+      if (!dryRun) jsonWrite(next);
+      out({ ok: true, mode: MODE, dryRun, action: 'task-add', task: fullTask });
+      return;
+    }
+
+    case 'task-done':
+    case 'task-undone': {
+      const id = args[0];
+      const doneBy = args[1] ?? 'cli';
+      const idx = (data.tasks ?? []).findIndex(t => t.id === id);
+      if (idx < 0) fail(`task ${id} not found`);
+      const before = data.tasks[idx];
+      const nowDone = cmd === 'task-done';
+      const after = {
+        ...before,
+        done: nowDone,
+        doneAt: nowDone ? new Date().toISOString() : undefined,
+        doneBy: nowDone ? doneBy : undefined,
+      };
+      const tasks = [...data.tasks];
+      tasks[idx] = after;
+      const next = { ...data, tasks };
+      appendLog(next, {
+        taskId: id,
+        actor: doneBy,
+        action: nowDone ? 'done:true' : 'done:false',
+        before: { done: before.done },
+        after: { done: nowDone },
+      });
+      if (!dryRun) jsonWrite(next);
+      out({ ok: true, mode: MODE, dryRun, action: cmd, task: after });
+      return;
+    }
+
+    case 'task-remove': {
+      const id = args[0];
+      const before = (data.tasks ?? []).find(t => t.id === id);
+      if (!before) fail(`task ${id} not found`);
+      const next = { ...data, tasks: (data.tasks ?? []).filter(t => t.id !== id) };
+      appendLog(next, {
+        taskId: id,
+        actor: before.reporter ?? 'cli',
+        action: 'removed',
+        before,
+      });
+      if (!dryRun) jsonWrite(next);
+      out({ ok: true, mode: MODE, dryRun, action: 'task-remove', removed: before });
+      return;
+    }
+
+    case 'task-list': {
+      const f = args[0] ? parseJson(args[0], 'filter') : {};
+      let list = data.tasks ?? [];
+      if (f.eventId) list = list.filter(t => t.eventId === f.eventId);
+      if (f.assignee) list = list.filter(t => t.assignees?.includes(f.assignee));
+      if (f.openOnly) list = list.filter(t => !t.done);
+      if (f.doneOnly) list = list.filter(t => t.done);
+      out({ ok: true, mode: MODE, count: list.length, tasks: list });
+      return;
+    }
+
+    default:
+      fail(`unknown command: ${cmd}`);
+  }
+}
+
+// ─── Supabase helpers ──────────────────────────────────────
+function eventToRow(e) {
+  const row = {
+    id: e.id, lane: e.lane, title: e.title, subtitle: e.subtitle ?? null,
+    status: e.status ?? 'planned',
+    contacts: e.contacts ?? null, notes: e.notes ?? null,
+    owner: e.owner ?? null, links: e.links ?? null, tags: e.tags ?? null,
+    external_ids: e.externalIds ?? null,
+    needs_classification: !!e.needsClassification,
+    cancelled_at: e.cancelledAt ?? null, cancel_reason: e.cancelReason ?? null,
+    date_kind: e.date.kind,
+    date_iso: null, date_year: null, date_month: null, date_quarter: null, date_part_of_day: null,
+  };
+  if (e.date.kind === 'date') {
+    row.date_iso = e.date.iso;
+    row.date_part_of_day = e.date.partOfDay ?? null;
+  } else if (e.date.kind === 'month') {
+    row.date_year = e.date.year; row.date_month = e.date.month;
+  } else if (e.date.kind === 'quarter') {
+    row.date_year = e.date.year; row.date_quarter = e.date.quarter;
+  }
+  return row;
+}
+
+// ─── Supabase mode dispatcher ──────────────────────────────
+async function handleSupabase() {
+  const s = await supa();
+  switch (cmd) {
+    case 'read': {
+      const [e, t, a, m] = await Promise.all([
+        s.from('timeline_events').select('*'),
+        s.from('timeline_tasks').select('*'),
+        s.from('timeline_reusable_assets').select('*'),
+        s.from('timeline_meta').select('*').eq('id', 'singleton').single(),
+      ]);
+      out({
+        ok: true,
+        mode: MODE,
+        events: e.data ?? [],
+        tasks: t.data ?? [],
+        reusableAssets: a.data ?? [],
+        meta: m.data ?? null,
+      });
+      return;
+    }
+    case 'event-add': {
+      const ev = parseJson(args[0] ?? '', 'event');
+      if (!ev?.id || !ev?.title || !ev?.lane || !ev?.date) fail('event needs {id,lane,title,date,status}');
+      const row = eventToRow(ev);
+      if (dryRun) { out({ ok: true, mode: MODE, dryRun, action: 'event-add', row }); return; }
+      const { error } = await s.from('timeline_events').upsert(row);
+      if (error) fail(error.message);
+      out({ ok: true, mode: MODE, action: 'event-add', event: row });
+      return;
+    }
+    case 'event-update': {
+      const id = args[0];
+      const patch = parseJson(args[1] ?? '{}', 'patch');
+      const { data: cur, error: rErr } = await s.from('timeline_events').select('*').eq('id', id).single();
+      if (rErr) fail(rErr.message);
+      if (!cur) fail(`event ${id} not found`);
+      const merged = { ...cur, ...eventToRow({ ...cur, ...patch, id }) };
+      if (dryRun) { out({ ok: true, mode: MODE, dryRun, action: 'event-update', before: cur, after: merged }); return; }
+      const { error } = await s.from('timeline_events').update(merged).eq('id', id);
+      if (error) fail(error.message);
+      out({ ok: true, mode: MODE, action: 'event-update', id });
+      return;
+    }
+    case 'event-cancel': {
+      const id = args[0];
+      const reason = args[1];
+      const update = { status: 'cancelled', cancelled_at: new Date().toISOString(), cancel_reason: reason ?? null };
+      if (dryRun) { out({ ok: true, mode: MODE, dryRun, action: 'event-cancel', id, update }); return; }
+      const { error } = await s.from('timeline_events').update(update).eq('id', id);
+      if (error) fail(error.message);
+      out({ ok: true, mode: MODE, action: 'event-cancel', id });
+      return;
+    }
+    case 'event-remove': {
+      const id = args[0];
+      if (dryRun) { out({ ok: true, mode: MODE, dryRun, action: 'event-remove', id }); return; }
+      const { error } = await s.from('timeline_events').delete().eq('id', id);
+      if (error) fail(error.message);
+      out({ ok: true, mode: MODE, action: 'event-remove', id });
+      return;
+    }
+    case 'task-add': {
+      const t = parseJson(args[0] ?? '', 'task');
+      if (!t?.title) fail('task needs {title}');
+      if (dryRun) { out({ ok: true, mode: MODE, dryRun, task: t }); return; }
+      const row = {
+        id: t.id ?? newId('t'),
+        event_id: t.eventId ?? null,
+        title: t.title,
+        assignees: t.assignees ?? [],
+        reporter: t.reporter ?? null,
+        due_date: t.dueDate ?? null,
+        priority: t.priority ?? 'med',
+        done: false,
+        source_excerpt: t.sourceExcerpt ?? null,
+      };
+      const { error } = await s.from('timeline_tasks').upsert(row);
+      if (error) fail(error.message);
+      await s.from('timeline_task_log').insert({
+        task_id: row.id, actor: row.reporter, action: 'created', after_value: row,
+      });
+      out({ ok: true, mode: MODE, action: 'task-add', task: row });
+      return;
+    }
+    case 'task-done':
+    case 'task-undone': {
+      const id = args[0];
+      const doneBy = args[1] ?? 'cli';
+      const nowDone = cmd === 'task-done';
+      const update = {
+        done: nowDone,
+        done_at: nowDone ? new Date().toISOString() : null,
+        done_by: nowDone ? doneBy : null,
+      };
+      if (dryRun) { out({ ok: true, mode: MODE, dryRun, update }); return; }
+      const { error } = await s.from('timeline_tasks').update(update).eq('id', id);
+      if (error) fail(error.message);
+      await s.from('timeline_task_log').insert({
+        task_id: id, actor: doneBy, action: nowDone ? 'done:true' : 'done:false', after_value: update,
+      });
+      out({ ok: true, mode: MODE, action: cmd, taskId: id });
+      return;
+    }
+    case 'task-remove': {
+      const id = args[0];
+      if (dryRun) { out({ ok: true, mode: MODE, dryRun, removedId: id }); return; }
+      await s.from('timeline_task_log').insert({ task_id: id, actor: 'cli', action: 'removed' });
+      const { error } = await s.from('timeline_tasks').delete().eq('id', id);
+      if (error) fail(error.message);
+      out({ ok: true, mode: MODE, action: 'task-remove', removedId: id });
+      return;
+    }
+    case 'task-list': {
+      const f = args[0] ? parseJson(args[0], 'filter') : {};
+      let q = s.from('timeline_tasks').select('*');
+      if (f.eventId) q = q.eq('event_id', f.eventId);
+      if (f.assignee) q = q.contains('assignees', [f.assignee]);
+      if (f.openOnly) q = q.eq('done', false);
+      if (f.doneOnly) q = q.eq('done', true);
+      const { data: rows, error } = await q;
+      if (error) fail(error.message);
+      out({ ok: true, mode: MODE, count: rows.length, tasks: rows });
+      return;
+    }
+    default:
+      fail(`supabase mode: ${cmd} not implemented yet`);
+  }
+}
+
+if (!cmd) {
+  out({
+    ok: false,
+    error: 'usage: cal-cli.mjs <cmd> [args] [--dry-run]',
+    cmds: [
+      'read', 'event-add', 'event-update', 'event-cancel', 'event-remove',
+      'task-add', 'task-update', 'task-done', 'task-undone', 'task-remove', 'task-list',
+    ],
+  });
+  process.exit(1);
+}
+
+(MODE === 'supabase' ? handleSupabase : handleJson)().catch(e => fail(e.message));

--- a/web/src/app/dashboard/actions/tasks.ts
+++ b/web/src/app/dashboard/actions/tasks.ts
@@ -1,0 +1,155 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { auth } from '@/lib/auth';
+import { defaultStore } from '@/lib/timeline/store';
+import type { SubTask, TaskPriority } from '@/lib/timeline/types';
+import { getMemberByEmail } from '@/lib/members';
+import { formatTaskAddedMessage, postDiscordMessage } from '@/lib/notify/discord';
+
+export interface TaskActionResult {
+  ok: boolean;
+  error?: string;
+  taskId?: string;
+}
+
+function newTaskId(): string {
+  return `t-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+async function currentDisplayName(): Promise<string | null> {
+  const session = await auth();
+  const email = session?.user?.email;
+  if (!email) return null;
+  const m = getMemberByEmail(email);
+  return m?.displayName ?? email.split('@')[0];
+}
+
+function eventDateToIso(d: { kind: string; iso?: string }): string | null {
+  if (d.kind === 'date' && d.iso) return d.iso;
+  return null;
+}
+
+function subtractDays(iso: string, n: number): string {
+  const [y, m, day] = iso.split('-').map(Number);
+  const t = new Date(Date.UTC(y, m - 1, day - n));
+  return t.toISOString().slice(0, 10);
+}
+
+export async function addTaskAction(input: {
+  eventId?: string;
+  title: string;
+  assignees: string[];
+  dueDate?: string;
+  priority?: TaskPriority;
+  sourceExcerpt?: string;
+}): Promise<TaskActionResult> {
+  const session = await auth();
+  if (!session?.user?.email) return { ok: false, error: '로그인이 필요합니다.' };
+
+  const title = input.title.trim();
+  if (!title) return { ok: false, error: '제목을 입력해주세요.' };
+  if (title.length > 500) return { ok: false, error: '제목이 너무 깁니다 (500자 이내).' };
+
+  const store = defaultStore();
+
+  // Due default: event 첨부 + due 미지정이면 event date - 3일
+  let dueDate = input.dueDate;
+  let eventTitle: string | undefined;
+  if (input.eventId) {
+    const data = await store.read();
+    const ev = data.events.find(e => e.id === input.eventId);
+    if (ev) {
+      eventTitle = ev.title;
+      if (!dueDate) {
+        const evIso = eventDateToIso(ev.date as { kind: string; iso?: string });
+        if (evIso) dueDate = subtractDays(evIso, 3);
+      }
+    }
+  }
+
+  const task: SubTask = {
+    id: newTaskId(),
+    eventId: input.eventId,
+    title,
+    assignees: input.assignees.filter(Boolean),
+    reporter: session.user.email,
+    dueDate,
+    priority: input.priority ?? 'med',
+    done: false,
+    sourceExcerpt: input.sourceExcerpt,
+    createdAt: new Date().toISOString(),
+  };
+
+  try {
+    await store.addTask(task);
+    revalidatePath('/dashboard');
+
+    // Discord notify (no-op if env unset)
+    if (task.assignees.length > 0) {
+      const reporterName = await currentDisplayName();
+      void postDiscordMessage(
+        formatTaskAddedMessage({
+          title: task.title,
+          assignees: task.assignees,
+          dueDate: task.dueDate,
+          eventTitle,
+          reporterName: reporterName ?? undefined,
+        }),
+      );
+    }
+
+    return { ok: true, taskId: task.id };
+  } catch (e) {
+    return { ok: false, error: (e as Error).message };
+  }
+}
+
+export async function toggleTaskDoneAction(taskId: string): Promise<TaskActionResult> {
+  const session = await auth();
+  if (!session?.user?.email) return { ok: false, error: '로그인이 필요합니다.' };
+  const myName = await currentDisplayName();
+  if (!myName) return { ok: false, error: '로그인이 필요합니다.' };
+
+  const store = defaultStore();
+  const data = await store.read();
+  const task = (data.tasks ?? []).find(t => t.id === taskId);
+  if (!task) return { ok: false, error: '없는 할 일입니다.' };
+
+  // 권한: reporter (email) 또는 assignees (displayName) 포함
+  const canToggle =
+    task.reporter === session.user.email || task.assignees.includes(myName);
+  if (!canToggle) {
+    return { ok: false, error: '권한이 없습니다 (reporter 또는 assignee만 체크 가능).' };
+  }
+
+  try {
+    await store.toggleTaskDone(taskId, myName);
+    revalidatePath('/dashboard');
+    return { ok: true, taskId };
+  } catch (e) {
+    return { ok: false, error: (e as Error).message };
+  }
+}
+
+export async function removeTaskAction(taskId: string): Promise<TaskActionResult> {
+  const session = await auth();
+  if (!session?.user?.email) return { ok: false, error: '로그인이 필요합니다.' };
+
+  const store = defaultStore();
+  const data = await store.read();
+  const task = (data.tasks ?? []).find(t => t.id === taskId);
+  if (!task) return { ok: false, error: '없는 할 일입니다.' };
+
+  if (task.reporter !== session.user.email) {
+    return { ok: false, error: '권한이 없습니다 (reporter만 삭제 가능).' };
+  }
+
+  try {
+    await store.removeTask(taskId);
+    revalidatePath('/dashboard');
+    return { ok: true, taskId };
+  } catch (e) {
+    return { ok: false, error: (e as Error).message };
+  }
+}

--- a/web/src/app/dashboard/components/CalendarTab.tsx
+++ b/web/src/app/dashboard/components/CalendarTab.tsx
@@ -12,6 +12,7 @@ import EventDetail from './calendar/EventDetail';
 import DayDetail from './calendar/DayDetail';
 import SyncButton from './calendar/SyncButton';
 import { isHoliday, isWeekend } from '@/lib/timeline/holidays';
+import { buildProgressMap } from '@/lib/timeline/progress';
 
 type ViewMode = 'grid' | 'timeline';
 
@@ -59,6 +60,8 @@ export default function CalendarTab({ data, holidays, notes, members, sheetsRead
   const dayHoliday = selectedDay ? isHoliday(selectedDay, holidays) : null;
   const dayWeekend = selectedDay ? isWeekend(selectedDay) : null;
 
+  const progressMap = useMemo(() => buildProgressMap(data.tasks), [data.tasks]);
+
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px] gap-3">
       {/* Main calendar column */}
@@ -104,6 +107,7 @@ export default function CalendarTab({ data, holidays, notes, members, sheetsRead
             holidays={holidays}
             selectedId={selected?.id ?? null}
             selectedDay={selectedDay}
+            progressMap={progressMap}
             onSelectEvent={onSelectEvent}
             onSelectDay={onSelectDay}
           />
@@ -112,6 +116,7 @@ export default function CalendarTab({ data, holidays, notes, members, sheetsRead
             data={data}
             holidays={holidays}
             selectedId={selected?.id ?? null}
+            progressMap={progressMap}
             onSelectEvent={onSelectEvent}
           />
         )}
@@ -136,6 +141,8 @@ export default function CalendarTab({ data, holidays, notes, members, sheetsRead
             <EventDetail
               event={selected}
               lanes={data.lanes}
+              tasks={data.tasks}
+              members={members}
               onClose={() => {
                 setSelected(null);
                 setSelectedDay(null);
@@ -149,6 +156,7 @@ export default function CalendarTab({ data, holidays, notes, members, sheetsRead
             holiday={dayHoliday}
             weekend={dayWeekend}
             lanes={data.lanes}
+            progressMap={progressMap}
             onSelectEvent={onSelectEvent}
             onClose={() => setSelectedDay(null)}
           />

--- a/web/src/app/dashboard/components/calendar/DayDetail.tsx
+++ b/web/src/app/dashboard/components/calendar/DayDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { TimelineEvent, TimelineLanesMeta, Holiday } from '@/lib/timeline/types';
+import type { TimelineEvent, TimelineLanesMeta, Holiday, EventProgress } from '@/lib/timeline/types';
 import EventCard from './EventCard';
 
 interface Props {
@@ -9,6 +9,7 @@ interface Props {
   holiday?: Holiday | null;
   weekend?: 'sat' | 'sun' | null;
   lanes: TimelineLanesMeta;
+  progressMap?: Map<string, EventProgress>;
   onSelectEvent: (ev: TimelineEvent) => void;
   onClose?: () => void;
 }
@@ -21,6 +22,7 @@ export default function DayDetail({
   holiday,
   weekend,
   lanes,
+  progressMap,
   onSelectEvent,
   onClose,
 }: Props) {
@@ -82,7 +84,12 @@ export default function DayDetail({
                   onClick={() => onSelectEvent(ev)}
                   className="w-full text-left transition-all hover:brightness-110"
                 >
-                  <EventCard event={ev} lanes={lanes} compact />
+                  <EventCard
+                    event={ev}
+                    lanes={lanes}
+                    compact
+                    progress={progressMap?.get(ev.id)}
+                  />
                 </button>
               ))}
               <div className="text-[0.62rem] text-[#6e7681] text-center pt-1">

--- a/web/src/app/dashboard/components/calendar/EventCard.tsx
+++ b/web/src/app/dashboard/components/calendar/EventCard.tsx
@@ -25,13 +25,17 @@ export default function EventCard({
   event,
   lanes,
   compact = false,
+  progress,
 }: {
   event: TimelineEvent;
   lanes: TimelineLanesMeta;
   compact?: boolean;
+  progress?: { done: number; total: number; overdue: number };
 }) {
   const lane = lanes[event.lane];
   const cancelled = event.status === 'cancelled';
+  const hasTasks = progress && progress.total > 0;
+  const allDone = hasTasks && progress!.done === progress!.total;
   return (
     <div
       className={`relative rounded-lg border bg-[#161b22] border-[#30363d] ${
@@ -70,6 +74,26 @@ export default function EventCard({
       <div className={`text-[#8b949e] ${compact ? 'text-[0.62rem]' : 'text-[0.68rem]'} mt-1`}>
         {fuzzyDateLabel(event.date)}
       </div>
+      {hasTasks && (
+        <div className={`flex items-center gap-1 ${compact ? 'mt-0.5' : 'mt-1'}`}>
+          <div className="flex-1 h-1 rounded-full bg-[#21262d] overflow-hidden">
+            <div
+              className={`h-full ${
+                allDone
+                  ? 'bg-[#27ae60]'
+                  : progress!.overdue > 0
+                  ? 'bg-[#e74c3c]'
+                  : 'bg-[#58a6ff]'
+              }`}
+              style={{ width: `${(progress!.done / progress!.total) * 100}%` }}
+            />
+          </div>
+          <span className={`${compact ? 'text-[0.55rem]' : 'text-[0.6rem]'} text-[#8b949e] font-mono`}>
+            {progress!.done}/{progress!.total}
+            {progress!.overdue > 0 && ' 🔥'}
+          </span>
+        </div>
+      )}
       {!compact && event.notes && event.notes.length > 0 && (
         <ul className="mt-1.5 space-y-0.5">
           {event.notes.map((n, i) => (

--- a/web/src/app/dashboard/components/calendar/EventDetail.tsx
+++ b/web/src/app/dashboard/components/calendar/EventDetail.tsx
@@ -1,7 +1,14 @@
 'use client';
 
-import type { TimelineEvent, TimelineLanesMeta, EventStatus } from '@/lib/timeline/types';
+import type {
+  TimelineEvent,
+  TimelineLanesMeta,
+  EventStatus,
+  SubTask,
+} from '@/lib/timeline/types';
 import { fuzzyDateLabel } from '@/lib/timeline/dateUtil';
+import type { DashboardMember } from '../../types';
+import TaskChecklist from './TaskChecklist';
 
 const STATUS: Record<EventStatus, { label: string; cls: string }> = {
   planned: { label: '예정', cls: 'bg-[rgba(31,111,235,0.18)] text-[#58a6ff]' },
@@ -15,10 +22,12 @@ const STATUS: Record<EventStatus, { label: string; cls: string }> = {
 interface Props {
   event: TimelineEvent | null;
   lanes: TimelineLanesMeta;
+  tasks?: SubTask[];
+  members?: DashboardMember[];
   onClose?: () => void;
 }
 
-export default function EventDetail({ event, lanes, onClose }: Props) {
+export default function EventDetail({ event, lanes, tasks, members, onClose }: Props) {
   if (!event) {
     return (
       <div className="bg-[#161b22] border border-[#30363d] rounded-xl p-5 flex flex-col items-center justify-center text-center min-h-[200px]">
@@ -119,6 +128,17 @@ export default function EventDetail({ event, lanes, onClose }: Props) {
               </ul>
             }
           />
+        )}
+
+        {/* Sub-tasks 체크리스트 + 진척도 */}
+        {members && (
+          <div className="border-t border-[#21262d] pt-3">
+            <TaskChecklist
+              event={event}
+              tasks={(tasks ?? []).filter(t => t.eventId === event.id)}
+              members={members}
+            />
+          </div>
         )}
 
         {/* Cancel reason */}

--- a/web/src/app/dashboard/components/calendar/GridView.tsx
+++ b/web/src/app/dashboard/components/calendar/GridView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useRef, useState } from 'react';
-import type { TimelineData, TimelineEvent, Holiday } from '@/lib/timeline/types';
+import type { TimelineData, TimelineEvent, Holiday, EventProgress } from '@/lib/timeline/types';
 import { fuzzyDateMatchesMonth } from '@/lib/timeline/dateUtil';
 import { isHoliday, isWeekend } from '@/lib/timeline/holidays';
 import EventCard from './EventCard';
@@ -11,6 +11,7 @@ interface Props {
   holidays: Holiday[];
   selectedId?: string | null;
   selectedDay?: string | null;
+  progressMap?: Map<string, EventProgress>;
   onSelectEvent: (ev: TimelineEvent) => void;
   onSelectDay: (iso: string) => void;
   initialYear?: number;
@@ -37,6 +38,7 @@ export default function GridView({
   holidays,
   selectedId,
   selectedDay,
+  progressMap,
   onSelectEvent,
   onSelectDay,
   initialYear,
@@ -249,7 +251,12 @@ export default function GridView({
                   selectedId === ev.id ? 'ring-1 ring-[#58a6ff] rounded-lg' : ''
                 }`}
               >
-                <EventCard event={ev} lanes={data.lanes} compact />
+                <EventCard
+                  event={ev}
+                  lanes={data.lanes}
+                  compact
+                  progress={progressMap?.get(ev.id)}
+                />
               </button>
             ))}
           </div>

--- a/web/src/app/dashboard/components/calendar/MentionInput.tsx
+++ b/web/src/app/dashboard/components/calendar/MentionInput.tsx
@@ -10,6 +10,9 @@ interface Props {
   maxLength?: number;
   disabled?: boolean;
   rows?: number;
+  // Enter (without Shift) when dropdown is closed → submit.
+  // Useful for one-line inputs like task title bar.
+  onEnter?: () => void;
 }
 
 interface DropdownState {
@@ -36,6 +39,7 @@ export default function MentionInput({
   maxLength = 2000,
   disabled,
   rows = 3,
+  onEnter,
 }: Props) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [dropdown, setDropdown] = useState<DropdownState>(initialDropdown);
@@ -60,7 +64,13 @@ export default function MentionInput({
       setDropdown(initialDropdown);
       return;
     }
-    setDropdown({ open: true, start: at, query: segment, items, index: 0 });
+    // Preserve index when the @ anchor & query are unchanged (e.g. ArrowDown keyup re-run).
+    // Only reset index when items list changed shape.
+    setDropdown(prev => {
+      const sameAnchor = prev.open && prev.start === at && prev.query === segment;
+      const idx = sameAnchor ? Math.min(prev.index, items.length - 1) : 0;
+      return { open: true, start: at, query: segment, items, index: idx };
+    });
   };
 
   const insertMention = (name: string) => {
@@ -80,18 +90,25 @@ export default function MentionInput({
   };
 
   const handleKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (!dropdown.open) return;
-    if (e.key === 'ArrowDown') {
+    if (dropdown.open) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setDropdown(d => ({ ...d, index: (d.index + 1) % d.items.length }));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setDropdown(d => ({ ...d, index: (d.index - 1 + d.items.length) % d.items.length }));
+      } else if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault();
+        insertMention(dropdown.items[dropdown.index]);
+      } else if (e.key === 'Escape') {
+        setDropdown(initialDropdown);
+      }
+      return;
+    }
+    // Dropdown closed: Enter (no Shift) → submit if onEnter provided
+    if (e.key === 'Enter' && !e.shiftKey && onEnter) {
       e.preventDefault();
-      setDropdown(d => ({ ...d, index: (d.index + 1) % d.items.length }));
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setDropdown(d => ({ ...d, index: (d.index - 1 + d.items.length) % d.items.length }));
-    } else if (e.key === 'Enter' || e.key === 'Tab') {
-      e.preventDefault();
-      insertMention(dropdown.items[dropdown.index]);
-    } else if (e.key === 'Escape') {
-      setDropdown(initialDropdown);
+      onEnter();
     }
   };
 

--- a/web/src/app/dashboard/components/calendar/NotesPanel.tsx
+++ b/web/src/app/dashboard/components/calendar/NotesPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import type { DashboardMember } from '../../types';
 import type { Note, NoteCategory } from '@/lib/sheets/notes';
@@ -22,6 +23,7 @@ interface Props {
 }
 
 export default function NotesPanel({ notes, members, sheetsReady }: Props) {
+  const router = useRouter();
   const { data: session } = useSession();
   const [active, setActive] = useState<NoteCategory>('spec');
   const [content, setContent] = useState('');
@@ -59,6 +61,7 @@ export default function NotesPanel({ notes, members, sheetsReady }: Props) {
       const r = await createNoteAction({ category: active, content: text });
       if (r.ok) {
         setContent('');
+        router.refresh();
       } else {
         setError(r.error ?? '등록 실패');
       }
@@ -68,7 +71,9 @@ export default function NotesPanel({ notes, members, sheetsReady }: Props) {
   const onDelete = (id: string) => {
     if (!confirm('이 메모를 삭제할까요?')) return;
     startTransition(async () => {
-      await deleteNoteAction(id);
+      const r = await deleteNoteAction(id);
+      if (r.ok) router.refresh();
+      else setError(r.error ?? '삭제 실패');
     });
   };
 

--- a/web/src/app/dashboard/components/calendar/TaskChecklist.tsx
+++ b/web/src/app/dashboard/components/calendar/TaskChecklist.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import type { SubTask, TimelineEvent } from '@/lib/timeline/types';
+import type { DashboardMember } from '../../types';
+import {
+  addTaskAction,
+  toggleTaskDoneAction,
+  removeTaskAction,
+} from '../../actions/tasks';
+import MentionInput from './MentionInput';
+
+interface Props {
+  event: TimelineEvent;
+  tasks: SubTask[];
+  members: DashboardMember[];
+}
+
+const PRIORITY_BADGE: Record<NonNullable<SubTask['priority']>, string> = {
+  low: 'bg-[rgba(139,148,158,0.15)] text-[#8b949e]',
+  med: 'bg-[rgba(31,111,235,0.15)] text-[#58a6ff]',
+  high: 'bg-[rgba(231,76,60,0.18)] text-[#e74c3c]',
+};
+
+function parseInputLine(line: string, members: DashboardMember[]): {
+  title: string;
+  assignees: string[];
+  dueDate?: string;
+  priority?: SubTask['priority'];
+} {
+  let text = line.trim();
+  const memberSet = new Set(members.map(m => m.displayName));
+  const assignees = new Set<string>();
+  text = text.replace(/@([A-Za-z가-힣][A-Za-z0-9가-힣_]*)/g, (_m, name) => {
+    if (memberSet.has(name)) assignees.add(name);
+    return '';
+  });
+
+  let dueDate: string | undefined;
+  // YYYY-MM-DD
+  let m = text.match(/(\d{4})-(\d{1,2})-(\d{1,2})/);
+  if (m) {
+    dueDate = `${m[1]}-${m[2].padStart(2, '0')}-${m[3].padStart(2, '0')}`;
+    text = text.replace(m[0], '');
+  } else {
+    // M/D or MM/DD (current year)
+    m = text.match(/(?:^|\s)(\d{1,2})\/(\d{1,2})(?:\s|$|까지)/);
+    if (m) {
+      const now = new Date();
+      dueDate = `${now.getFullYear()}-${m[1].padStart(2, '0')}-${m[2].padStart(2, '0')}`;
+      text = text.replace(m[0], ' ');
+    }
+  }
+
+  let priority: SubTask['priority'] | undefined;
+  if (/긴급|급함|urgent|high/i.test(text)) {
+    priority = 'high';
+    text = text.replace(/긴급|급함|urgent|high/gi, '');
+  } else if (/낮음|low/i.test(text)) {
+    priority = 'low';
+    text = text.replace(/낮음|low/gi, '');
+  }
+
+  // strip trailing "까지" / "에" particle
+  text = text.replace(/까지|에|by/g, '').replace(/\s+/g, ' ').trim();
+
+  return {
+    title: text,
+    assignees: [...assignees],
+    dueDate,
+    priority,
+  };
+}
+
+function isOverdue(t: SubTask): boolean {
+  if (!t.dueDate || t.done) return false;
+  return t.dueDate < new Date().toISOString().slice(0, 10);
+}
+
+export default function TaskChecklist({ event, tasks, members }: Props) {
+  const router = useRouter();
+  const { data: session } = useSession();
+  const [input, setInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const myEmail = session?.user?.email ?? null;
+  const myDisplay = (session?.user as { displayName?: string; name?: string } | undefined)
+    ?.displayName
+    ?? session?.user?.name
+    ?? null;
+
+  const canToggle = (t: SubTask): boolean => {
+    if (!myEmail) return false;
+    if (t.reporter === myEmail) return true;
+    if (myDisplay && t.assignees.includes(myDisplay)) return true;
+    return false;
+  };
+
+  const total = tasks.length;
+  const done = tasks.filter(t => t.done).length;
+  const overdueCount = tasks.filter(isOverdue).length;
+  const progress = total > 0 ? done / total : 0;
+  const allDone = total > 0 && done === total;
+
+  const onAdd = () => {
+    setError(null);
+    const text = input.trim();
+    if (!text) return;
+    const parsed = parseInputLine(text, members);
+    if (!parsed.title) {
+      setError('내용을 입력해주세요.');
+      return;
+    }
+    startTransition(async () => {
+      const r = await addTaskAction({
+        eventId: event.id,
+        title: parsed.title,
+        assignees: parsed.assignees,
+        dueDate: parsed.dueDate,
+        priority: parsed.priority,
+        sourceExcerpt: text,
+      });
+      if (r.ok) {
+        setInput('');
+        router.refresh();
+      } else setError(r.error ?? '등록 실패');
+    });
+  };
+
+  const onToggle = (id: string) => {
+    setError(null);
+    startTransition(async () => {
+      const r = await toggleTaskDoneAction(id);
+      if (r.ok) router.refresh();
+      else setError(r.error ?? '실패');
+    });
+  };
+
+  const onRemove = (id: string) => {
+    if (!confirm('이 할 일을 삭제할까요?')) return;
+    startTransition(async () => {
+      const r = await removeTaskAction(id);
+      if (r.ok) router.refresh();
+      else setError(r.error ?? '삭제 실패');
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="text-[0.62rem] uppercase tracking-wide text-[#6e7681] font-semibold">
+        진척도
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="flex-1 h-1.5 rounded-full bg-[#21262d] overflow-hidden">
+          <div
+            className={`h-full transition-all ${
+              allDone ? 'bg-[#27ae60]' : overdueCount > 0 ? 'bg-[#e74c3c]' : 'bg-[#58a6ff]'
+            }`}
+            style={{ width: `${progress * 100}%` }}
+          />
+        </div>
+        <div className="text-[0.7rem] text-[#e6edf3] font-mono">
+          {done}/{total}
+        </div>
+        {overdueCount > 0 && (
+          <span className="text-[0.62rem] text-[#e74c3c]" title="지연된 할 일">
+            🔥 {overdueCount}
+          </span>
+        )}
+      </div>
+
+      <div className="text-[0.62rem] uppercase tracking-wide text-[#6e7681] font-semibold pt-2">
+        할 일 ({total})
+      </div>
+      {total === 0 ? (
+        <div className="text-[0.7rem] text-[#6e7681] py-1">아직 할 일이 없습니다.</div>
+      ) : (
+        <ul className="space-y-1.5">
+          {tasks.map(t => {
+            const overdue = isOverdue(t);
+            const mine = myEmail && t.reporter === myEmail;
+            const togglable = canToggle(t);
+            return (
+              <li
+                key={t.id}
+                className={`flex items-start gap-2 rounded-md px-1.5 py-1 ${
+                  t.done ? 'opacity-60' : ''
+                } ${overdue ? 'bg-[rgba(231,76,60,0.06)]' : ''}`}
+              >
+                <button
+                  type="button"
+                  onClick={() => onToggle(t.id)}
+                  disabled={pending || !togglable}
+                  title={
+                    togglable
+                      ? t.done
+                        ? '체크 해제'
+                        : '완료 처리'
+                      : 'reporter 또는 assignee만 체크 가능'
+                  }
+                  className={`mt-0.5 w-3.5 h-3.5 shrink-0 rounded border ${
+                    t.done
+                      ? 'bg-[#27ae60] border-[#27ae60] text-white'
+                      : togglable
+                      ? 'bg-transparent border-[#30363d] hover:border-[#58a6ff]'
+                      : 'bg-transparent border-[#21262d] cursor-not-allowed'
+                  } flex items-center justify-center text-[0.6rem] leading-none`}
+                  aria-pressed={t.done}
+                  aria-disabled={!togglable}
+                >
+                  {t.done && '✓'}
+                </button>
+                <div className="min-w-0 flex-1">
+                  <div className={`text-[0.78rem] ${t.done ? 'line-through' : ''} break-words`}>
+                    {t.title}
+                  </div>
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-0.5 text-[0.62rem] text-[#8b949e]">
+                    {t.assignees.length > 0 && (
+                      <span>
+                        {t.assignees.map(a => (
+                          <span
+                            key={a}
+                            className="inline-block px-1 rounded bg-[rgba(31,111,235,0.18)] text-[#58a6ff] mr-1"
+                          >
+                            @{a}
+                          </span>
+                        ))}
+                      </span>
+                    )}
+                    {t.dueDate && (
+                      <span className={overdue ? 'text-[#e74c3c] font-semibold' : ''}>
+                        due {t.dueDate}
+                        {overdue && ' 🔥'}
+                      </span>
+                    )}
+                    {t.priority && t.priority !== 'med' && (
+                      <span className={`px-1 rounded ${PRIORITY_BADGE[t.priority]}`}>
+                        {t.priority}
+                      </span>
+                    )}
+                    {t.done && t.doneBy && <span>· {t.doneBy} 완료</span>}
+                  </div>
+                </div>
+                {mine && (
+                  <button
+                    type="button"
+                    onClick={() => onRemove(t.id)}
+                    disabled={pending}
+                    className="text-[0.62rem] text-[#6e7681] hover:text-[#e74c3c] shrink-0"
+                    aria-label="할 일 삭제"
+                  >
+                    ×
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {session ? (
+        <div className="pt-2 space-y-1">
+          <MentionInput
+            value={input}
+            onChange={setInput}
+            candidates={members.map(m => m.displayName)}
+            placeholder="예: @TJ 5/22까지 촬영 준비"
+            disabled={pending}
+            rows={2}
+            maxLength={500}
+            onEnter={onAdd}
+          />
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-[0.6rem] text-[#6e7681]">
+              @로 멤버 · 5/22 또는 2026-05-22 · 긴급/낮음 · Enter로 추가
+            </span>
+            <button
+              type="button"
+              onClick={onAdd}
+              disabled={pending || !input.trim()}
+              className={`text-[0.7rem] px-2 py-0.5 rounded-md font-semibold ${
+                pending || !input.trim()
+                  ? 'bg-[#1f6feb]/40 text-white/60 cursor-not-allowed'
+                  : 'bg-[#1f6feb] hover:bg-[#388bfd] text-white'
+              }`}
+            >
+              {pending ? '저장 중…' : '추가'}
+            </button>
+          </div>
+          {error && <div className="text-[0.66rem] text-[#e74c3c]">{error}</div>}
+        </div>
+      ) : (
+        <div className="text-[0.66rem] text-[#8b949e] pt-1">로그인하면 할 일 추가 가능.</div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/dashboard/components/calendar/TimelineView.tsx
+++ b/web/src/app/dashboard/components/calendar/TimelineView.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useMemo } from 'react';
-import type { TimelineData, TimelineEvent, Lane, Holiday } from '@/lib/timeline/types';
+import type { TimelineData, TimelineEvent, Lane, Holiday, EventProgress } from '@/lib/timeline/types';
 import EventCard from './EventCard';
 
 interface Props {
   data: TimelineData;
   holidays: Holiday[];
   selectedId?: string | null;
+  progressMap?: Map<string, EventProgress>;
   onSelectEvent: (ev: TimelineEvent) => void;
 }
 
@@ -42,7 +43,7 @@ function bucketOf(ev: TimelineEvent): Bucket {
   return 'other';
 }
 
-export default function TimelineView({ data, holidays, selectedId, onSelectEvent }: Props) {
+export default function TimelineView({ data, holidays, selectedId, progressMap, onSelectEvent }: Props) {
   const grouped = useMemo(() => {
     const result: Record<Lane, Record<Bucket, TimelineEvent[]>> = {
       direct: { apr: [], may: [], jun: [], 'q2-followup': [], other: [] },
@@ -124,7 +125,12 @@ export default function TimelineView({ data, holidays, selectedId, onSelectEvent
                           selectedId === ev.id ? 'ring-1 ring-[#58a6ff] rounded-lg' : ''
                         }`}
                       >
-                        <EventCard event={ev} lanes={data.lanes} compact />
+                        <EventCard
+                          event={ev}
+                          lanes={data.lanes}
+                          compact
+                          progress={progressMap?.get(ev.id)}
+                        />
                       </button>
                     ))
                   )}

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import type { TimelineData, Holiday } from '@/lib/timeline/types';
 import { getKoreanHolidays } from '@/lib/timeline/holidays.server';
 import { listNotes } from '@/lib/sheets/notes';
 import { isSheetsConfigured } from '@/lib/sheets/client';
+import { defaultStore } from '@/lib/timeline/store';
 
 export const metadata: Metadata = {
   title: 'Dashboard | HypeProof AI',
@@ -44,23 +45,30 @@ function loadMembers(): MembersData {
   });
 }
 
-function loadTimeline(): TimelineData {
-  return loadJsonFromDataDir<TimelineData>('project-timeline.json', {
-    version: 1,
-    updatedAt: '',
-    lanes: {
-      direct: { label: 'HypeProof Direct', color: '#a78bfa' },
-      channel: { label: 'Filamentree Channel', color: '#34d399' },
-      reusable: { label: 'Reusable Asset Layer', color: '#94a3b8' },
-    },
-    events: [],
-    reusableAssets: [],
-  });
+async function loadTimeline(): Promise<TimelineData> {
+  // Routes through the storage abstraction so JSON file ↔ Supabase swap is
+  // transparent (driven by TIMELINE_STORE env). The page must see the same
+  // data that server actions (tasks.ts) write to.
+  try {
+    return await defaultStore().read();
+  } catch {
+    return {
+      version: 1,
+      updatedAt: '',
+      lanes: {
+        direct: { label: 'HypeProof Direct', color: '#a78bfa' },
+        channel: { label: '비트리 channel', color: '#34d399' },
+        reusable: { label: 'Reusable Asset Layer', color: '#94a3b8' },
+      },
+      events: [],
+      reusableAssets: [],
+    };
+  }
 }
 
 export default async function DashboardPage() {
   const members = loadMembers();
-  const timeline = loadTimeline();
+  const timeline = await loadTimeline();
   const currentYear = new Date().getFullYear();
   const holidays: Holiday[] = [
     ...getKoreanHolidays(currentYear),

--- a/web/src/lib/notify/discord.ts
+++ b/web/src/lib/notify/discord.ts
@@ -1,0 +1,53 @@
+import 'server-only';
+
+/**
+ * Minimal Discord webhook poster. Optional — silently no-ops if URL absent.
+ *
+ * Set DISCORD_TASK_WEBHOOK_URL in env to enable.
+ * For richer formatting (embeds), upgrade later.
+ */
+export async function postDiscordMessage(content: string): Promise<{ ok: boolean }> {
+  const url = process.env.DISCORD_TASK_WEBHOOK_URL;
+  if (!url || !content.trim()) return { ok: false };
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: content.slice(0, 1900) }),
+    });
+    return { ok: res.ok };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/**
+ * Format a task notification with member mentions.
+ * Members can map displayName → Discord user id via DISCORD_MEMBER_IDS env (JSON).
+ */
+function resolveMention(displayName: string): string {
+  try {
+    const map = JSON.parse(process.env.DISCORD_MEMBER_IDS || '{}') as Record<string, string>;
+    const id = map[displayName];
+    return id ? `<@${id}>` : `@${displayName}`;
+  } catch {
+    return `@${displayName}`;
+  }
+}
+
+export function formatTaskAddedMessage(input: {
+  title: string;
+  assignees: string[];
+  dueDate?: string;
+  eventTitle?: string;
+  reporterName?: string;
+}): string {
+  const mentions = input.assignees.map(resolveMention).join(' ');
+  const meta: string[] = [];
+  if (input.dueDate) meta.push(`due ${input.dueDate}`);
+  if (input.eventTitle) meta.push(`📅 ${input.eventTitle}`);
+  const head = mentions ? `${mentions} ` : '';
+  const tail = meta.length ? ` _(${meta.join(' · ')})_` : '';
+  const by = input.reporterName ? ` — by ${input.reporterName}` : '';
+  return `${head}**${input.title}**${tail}${by}`;
+}

--- a/web/src/lib/timeline/progress.ts
+++ b/web/src/lib/timeline/progress.ts
@@ -1,0 +1,36 @@
+import type { SubTask, EventProgress } from './types';
+
+const isOverdue = (t: SubTask, todayIso: string): boolean =>
+  !!t.dueDate && !t.done && t.dueDate < todayIso;
+
+export function progressForEvent(
+  eventId: string,
+  tasks: SubTask[] | undefined,
+  todayIso: string = new Date().toISOString().slice(0, 10),
+): EventProgress | null {
+  if (!tasks || tasks.length === 0) return null;
+  const my = tasks.filter(t => t.eventId === eventId);
+  if (my.length === 0) return null;
+  return {
+    total: my.length,
+    done: my.filter(t => t.done).length,
+    overdue: my.filter(t => isOverdue(t, todayIso)).length,
+  };
+}
+
+export function buildProgressMap(
+  tasks: SubTask[] | undefined,
+): Map<string, EventProgress> {
+  const map = new Map<string, EventProgress>();
+  if (!tasks) return map;
+  const today = new Date().toISOString().slice(0, 10);
+  for (const t of tasks) {
+    if (!t.eventId) continue;
+    const cur = map.get(t.eventId) ?? { total: 0, done: 0, overdue: 0 };
+    cur.total += 1;
+    if (t.done) cur.done += 1;
+    if (isOverdue(t, today)) cur.overdue += 1;
+    map.set(t.eventId, cur);
+  }
+  return map;
+}

--- a/web/src/lib/timeline/store.ts
+++ b/web/src/lib/timeline/store.ts
@@ -1,6 +1,27 @@
 import path from 'path';
 import fs from 'fs';
-import type { TimelineData, TimelineEvent, ReusableAsset, PriorityBanner } from './types';
+import type {
+  TimelineData,
+  TimelineEvent,
+  ReusableAsset,
+  PriorityBanner,
+  SubTask,
+  TaskLogEntry,
+} from './types';
+
+function newLogId(): string {
+  return `log-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function appendLog(data: TimelineData, entry: Omit<TaskLogEntry, 'id' | 'createdAt'>): TaskLogEntry {
+  const log: TaskLogEntry = {
+    ...entry,
+    id: newLogId(),
+    createdAt: new Date().toISOString(),
+  };
+  // Mutates given object — caller wraps in {...data, taskLog: [...]}
+  return log;
+}
 
 export interface TimelineStore {
   read(): Promise<TimelineData>;
@@ -13,6 +34,11 @@ export interface TimelineStore {
   updateAsset(id: string, patch: Partial<ReusableAsset>): Promise<TimelineData>;
   removeAsset(id: string): Promise<TimelineData>;
   setPriorityBanner(b: PriorityBanner | undefined): Promise<TimelineData>;
+  // Sub-tasks
+  addTask(t: SubTask): Promise<TimelineData>;
+  updateTask(id: string, patch: Partial<SubTask>): Promise<TimelineData>;
+  toggleTaskDone(id: string, doneBy: string): Promise<TimelineData>;
+  removeTask(id: string): Promise<TimelineData>;
 }
 
 const EMPTY: TimelineData = {
@@ -20,11 +46,12 @@ const EMPTY: TimelineData = {
   updatedAt: '',
   lanes: {
     direct: { label: 'HypeProof Direct', color: '#a78bfa' },
-    channel: { label: 'Filamentree Channel', color: '#34d399' },
+    channel: { label: '비트리 channel', color: '#34d399' },
     reusable: { label: 'Reusable Asset Layer', color: '#94a3b8' },
   },
   events: [],
   reusableAssets: [],
+  tasks: [],
 };
 
 export function resolveTimelinePath(): string {
@@ -137,12 +164,114 @@ export class JsonFileStore implements TimelineStore {
     await this.write(next);
     return next;
   }
+
+  async addTask(t: SubTask): Promise<TimelineData> {
+    const data = await this.read();
+    const tasks = data.tasks ?? [];
+    if (tasks.some(x => x.id === t.id)) {
+      return this.updateTask(t.id, t);
+    }
+    const log = appendLog(data, {
+      taskId: t.id,
+      actor: t.reporter ?? 'unknown',
+      action: 'created',
+      after: t,
+    });
+    const next: TimelineData = {
+      ...data,
+      tasks: [...tasks, t],
+      taskLog: [...(data.taskLog ?? []), log],
+    };
+    await this.write(next);
+    return next;
+  }
+
+  async updateTask(id: string, patch: Partial<SubTask>): Promise<TimelineData> {
+    const data = await this.read();
+    const before = (data.tasks ?? []).find(t => t.id === id);
+    if (!before) return data;
+    const after: SubTask = { ...before, ...patch, id };
+    const tasks = (data.tasks ?? []).map(t => (t.id === id ? after : t));
+    const beforeRec = before as unknown as Record<string, unknown>;
+    const patchRec = patch as unknown as Record<string, unknown>;
+    const changedFields = Object.keys(patch).filter(
+      k => beforeRec[k] !== patchRec[k],
+    );
+    const log = appendLog(data, {
+      taskId: id,
+      actor: patch.reporter ?? before.reporter ?? 'unknown',
+      action: `updated:${changedFields.join(',') || '_'}`,
+      before,
+      after,
+    });
+    const next: TimelineData = { ...data, tasks, taskLog: [...(data.taskLog ?? []), log] };
+    await this.write(next);
+    return next;
+  }
+
+  async toggleTaskDone(id: string, doneBy: string): Promise<TimelineData> {
+    const data = await this.read();
+    const before = (data.tasks ?? []).find(t => t.id === id);
+    if (!before) return data;
+    const nowDone = !before.done;
+    const after: SubTask = {
+      ...before,
+      done: nowDone,
+      doneAt: nowDone ? new Date().toISOString() : undefined,
+      doneBy: nowDone ? doneBy : undefined,
+    };
+    const tasks = (data.tasks ?? []).map(t => (t.id === id ? after : t));
+    const log = appendLog(data, {
+      taskId: id,
+      actor: doneBy,
+      action: nowDone ? 'done:true' : 'done:false',
+      before: { done: before.done },
+      after: { done: nowDone, doneBy: after.doneBy, doneAt: after.doneAt },
+    });
+    const next: TimelineData = { ...data, tasks, taskLog: [...(data.taskLog ?? []), log] };
+    await this.write(next);
+    return next;
+  }
+
+  async removeTask(id: string): Promise<TimelineData> {
+    const data = await this.read();
+    const before = (data.tasks ?? []).find(t => t.id === id);
+    if (!before) return data;
+    const log = appendLog(data, {
+      taskId: id,
+      actor: before.reporter ?? 'unknown',
+      action: 'removed',
+      before,
+    });
+    const next: TimelineData = {
+      ...data,
+      tasks: (data.tasks ?? []).filter(t => t.id !== id),
+      taskLog: [...(data.taskLog ?? []), log],
+    };
+    await this.write(next);
+    return next;
+  }
 }
 
 let _store: TimelineStore | null = null;
 
+/**
+ * Default store selection (opt-in via env):
+ *   TIMELINE_STORE=supabase  → SupabaseTimelineStore
+ *   (unset / file)           → JsonFileStore (web/data/project-timeline.json)
+ *
+ * Migration plan: dual-write window optional, then flip TIMELINE_STORE.
+ */
 export function defaultStore(): TimelineStore {
-  if (!_store) _store = new JsonFileStore();
+  if (_store) return _store;
+  if (process.env.TIMELINE_STORE === 'supabase') {
+    // Lazy: avoid loading supabase code in environments that don't need it
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { SupabaseTimelineStore } = require('./supabaseStore') as typeof import('./supabaseStore');
+    _store = new SupabaseTimelineStore();
+  } else {
+    _store = new JsonFileStore();
+  }
   return _store;
 }
 

--- a/web/src/lib/timeline/supabaseStore.ts
+++ b/web/src/lib/timeline/supabaseStore.ts
@@ -1,0 +1,351 @@
+import 'server-only';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabase } from '@/lib/supabase';
+import type {
+  TimelineData,
+  TimelineEvent,
+  ReusableAsset,
+  PriorityBanner,
+  SubTask,
+  FuzzyDate,
+  TimelineLanesMeta,
+  Lane,
+  EventStatus,
+  AssetStatus,
+  TaskPriority,
+} from './types';
+import type { TimelineStore } from './store';
+
+interface EventRow {
+  id: string;
+  lane: Lane;
+  title: string;
+  subtitle: string | null;
+  status: EventStatus;
+  date_kind: FuzzyDate['kind'];
+  date_iso: string | null;
+  date_year: number | null;
+  date_month: number | null;
+  date_quarter: number | null;
+  date_part_of_day: 'AM' | 'PM' | null;
+  contacts: string[] | null;
+  notes: string[] | null;
+  owner: string | null;
+  links: { label: string; url: string }[] | null;
+  tags: string[] | null;
+  external_ids: { gcal?: string; supabase?: string } | null;
+  needs_classification: boolean;
+  cancelled_at: string | null;
+  cancel_reason: string | null;
+}
+
+interface TaskRow {
+  id: string;
+  event_id: string | null;
+  title: string;
+  assignees: string[];
+  reporter: string | null;
+  due_date: string | null;
+  priority: TaskPriority;
+  done: boolean;
+  done_at: string | null;
+  done_by: string | null;
+  source_excerpt: string | null;
+  created_at: string;
+}
+
+interface AssetRow {
+  id: string;
+  title: string;
+  subtitle: string | null;
+  status: AssetStatus;
+  owned_by: string | null;
+}
+
+interface MetaRow {
+  id: 'singleton';
+  priority_banner: PriorityBanner | null;
+  lanes: TimelineLanesMeta;
+  gcal: { calendarId?: string; lastSyncAt?: string } | null;
+  updated_at: string;
+}
+
+function rowToEvent(r: EventRow): TimelineEvent {
+  const date = rowToFuzzyDate(r);
+  return {
+    id: r.id,
+    lane: r.lane,
+    title: r.title,
+    subtitle: r.subtitle ?? undefined,
+    date,
+    status: r.status,
+    cancelledAt: r.cancelled_at ?? undefined,
+    cancelReason: r.cancel_reason ?? undefined,
+    contacts: r.contacts ?? undefined,
+    notes: r.notes ?? undefined,
+    owner: r.owner ?? undefined,
+    links: r.links ?? undefined,
+    tags: r.tags ?? undefined,
+    externalIds: r.external_ids ?? undefined,
+    needsClassification: r.needs_classification,
+  };
+}
+
+function rowToFuzzyDate(r: EventRow): FuzzyDate {
+  switch (r.date_kind) {
+    case 'date':
+      return {
+        kind: 'date',
+        iso: r.date_iso!,
+        partOfDay: r.date_part_of_day ?? undefined,
+      };
+    case 'month':
+      return { kind: 'month', year: r.date_year!, month: r.date_month! };
+    case 'quarter':
+      return {
+        kind: 'quarter',
+        year: r.date_year!,
+        quarter: r.date_quarter as 1 | 2 | 3 | 4,
+      };
+    case 'ongoing':
+      return { kind: 'ongoing' };
+  }
+}
+
+function eventToRow(e: TimelineEvent): Omit<EventRow, 'created_at' | 'updated_at'> {
+  const base = {
+    id: e.id,
+    lane: e.lane,
+    title: e.title,
+    subtitle: e.subtitle ?? null,
+    status: e.status,
+    contacts: e.contacts ?? null,
+    notes: e.notes ?? null,
+    owner: e.owner ?? null,
+    links: e.links ?? null,
+    tags: e.tags ?? null,
+    external_ids: e.externalIds ?? null,
+    needs_classification: !!e.needsClassification,
+    cancelled_at: e.cancelledAt ?? null,
+    cancel_reason: e.cancelReason ?? null,
+    date_kind: e.date.kind,
+    date_iso: null as string | null,
+    date_year: null as number | null,
+    date_month: null as number | null,
+    date_quarter: null as number | null,
+    date_part_of_day: null as 'AM' | 'PM' | null,
+  };
+  if (e.date.kind === 'date') {
+    base.date_iso = e.date.iso;
+    base.date_part_of_day = e.date.partOfDay ?? null;
+  } else if (e.date.kind === 'month') {
+    base.date_year = e.date.year;
+    base.date_month = e.date.month;
+  } else if (e.date.kind === 'quarter') {
+    base.date_year = e.date.year;
+    base.date_quarter = e.date.quarter;
+  }
+  return base;
+}
+
+function rowToTask(r: TaskRow): SubTask {
+  return {
+    id: r.id,
+    eventId: r.event_id ?? undefined,
+    title: r.title,
+    assignees: r.assignees,
+    reporter: r.reporter ?? undefined,
+    dueDate: r.due_date ?? undefined,
+    priority: r.priority,
+    done: r.done,
+    doneAt: r.done_at ?? undefined,
+    doneBy: r.done_by ?? undefined,
+    sourceExcerpt: r.source_excerpt ?? undefined,
+    createdAt: r.created_at,
+  };
+}
+
+function taskToRow(t: SubTask): Omit<TaskRow, 'created_at'> & { created_at?: string } {
+  return {
+    id: t.id,
+    event_id: t.eventId ?? null,
+    title: t.title,
+    assignees: t.assignees,
+    reporter: t.reporter ?? null,
+    due_date: t.dueDate ?? null,
+    priority: t.priority ?? 'med',
+    done: t.done,
+    done_at: t.doneAt ?? null,
+    done_by: t.doneBy ?? null,
+    source_excerpt: t.sourceExcerpt ?? null,
+    created_at: t.createdAt,
+  };
+}
+
+function rowToAsset(r: AssetRow): ReusableAsset {
+  return {
+    id: r.id,
+    title: r.title,
+    subtitle: r.subtitle ?? undefined,
+    status: r.status,
+    ownedBy: r.owned_by ?? undefined,
+  };
+}
+
+const DEFAULT_LANES: TimelineLanesMeta = {
+  direct: { label: 'HypeProof Direct', color: '#a78bfa' },
+  channel: { label: '비트리 channel', color: '#34d399' },
+  reusable: { label: 'Reusable Asset Layer', color: '#94a3b8' },
+};
+
+export class SupabaseTimelineStore implements TimelineStore {
+  // Lazy: don't touch Supabase until a method is actually called.
+  // Lets defaultStore() instantiate this without env vars set.
+  private _client: SupabaseClient | null;
+
+  constructor(client?: SupabaseClient) {
+    this._client = client ?? null;
+  }
+
+  private get client(): SupabaseClient {
+    if (!this._client) this._client = getSupabase();
+    return this._client;
+  }
+
+  async read(): Promise<TimelineData> {
+    const [events, tasks, assets, meta] = await Promise.all([
+      this.client.from('timeline_events').select('*'),
+      this.client.from('timeline_tasks').select('*'),
+      this.client.from('timeline_reusable_assets').select('*'),
+      this.client.from('timeline_meta').select('*').eq('id', 'singleton').single(),
+    ]);
+
+    const metaRow = meta.data as MetaRow | null;
+    return {
+      version: 1,
+      updatedAt: metaRow?.updated_at ?? new Date().toISOString(),
+      lanes: metaRow?.lanes ?? DEFAULT_LANES,
+      priorityBanner: metaRow?.priority_banner ?? undefined,
+      events: ((events.data as EventRow[] | null) ?? []).map(rowToEvent),
+      reusableAssets: ((assets.data as AssetRow[] | null) ?? []).map(rowToAsset),
+      tasks: ((tasks.data as TaskRow[] | null) ?? []).map(rowToTask),
+      gcal: metaRow?.gcal ?? undefined,
+    };
+  }
+
+  async write(_next: TimelineData): Promise<void> {
+    // Bulk write would require diffing; we expose granular methods instead.
+    throw new Error(
+      'SupabaseTimelineStore.write is not supported. Use granular add/update/remove methods.',
+    );
+  }
+
+  async addEvent(e: TimelineEvent): Promise<TimelineData> {
+    await this.client.from('timeline_events').upsert(eventToRow(e));
+    return this.read();
+  }
+
+  async updateEvent(id: string, patch: Partial<TimelineEvent>): Promise<TimelineData> {
+    const data = await this.read();
+    const existing = data.events.find(ev => ev.id === id);
+    if (!existing) return data;
+    const merged: TimelineEvent = { ...existing, ...patch, id };
+    await this.client.from('timeline_events').update(eventToRow(merged)).eq('id', id);
+    return this.read();
+  }
+
+  async cancelEvent(id: string, reason?: string): Promise<TimelineData> {
+    return this.updateEvent(id, {
+      status: 'cancelled',
+      cancelledAt: new Date().toISOString(),
+      cancelReason: reason,
+    });
+  }
+
+  async removeEvent(id: string): Promise<TimelineData> {
+    await this.client.from('timeline_events').delete().eq('id', id);
+    return this.read();
+  }
+
+  async addAsset(a: ReusableAsset): Promise<TimelineData> {
+    await this.client.from('timeline_reusable_assets').upsert({
+      id: a.id,
+      title: a.title,
+      subtitle: a.subtitle ?? null,
+      status: a.status,
+      owned_by: a.ownedBy ?? null,
+    });
+    return this.read();
+  }
+
+  async updateAsset(id: string, patch: Partial<ReusableAsset>): Promise<TimelineData> {
+    const merged: Partial<AssetRow> = {
+      title: patch.title,
+      subtitle: patch.subtitle ?? null,
+      status: patch.status,
+      owned_by: patch.ownedBy ?? null,
+    };
+    Object.keys(merged).forEach(k => (merged as any)[k] === undefined && delete (merged as any)[k]);
+    await this.client.from('timeline_reusable_assets').update(merged).eq('id', id);
+    return this.read();
+  }
+
+  async removeAsset(id: string): Promise<TimelineData> {
+    await this.client.from('timeline_reusable_assets').delete().eq('id', id);
+    return this.read();
+  }
+
+  async setPriorityBanner(b: PriorityBanner | undefined): Promise<TimelineData> {
+    await this.client
+      .from('timeline_meta')
+      .update({ priority_banner: b ?? null })
+      .eq('id', 'singleton');
+    return this.read();
+  }
+
+  async addTask(t: SubTask): Promise<TimelineData> {
+    await this.client.from('timeline_tasks').upsert(taskToRow(t));
+    await this.client.from('timeline_task_log').insert({
+      task_id: t.id,
+      actor: t.reporter ?? null,
+      action: 'created',
+      after_value: taskToRow(t),
+    });
+    return this.read();
+  }
+
+  async updateTask(id: string, patch: Partial<SubTask>): Promise<TimelineData> {
+    const data = await this.read();
+    const existing = (data.tasks ?? []).find(t => t.id === id);
+    if (!existing) return data;
+    const merged: SubTask = { ...existing, ...patch, id };
+    await this.client.from('timeline_tasks').update(taskToRow(merged)).eq('id', id);
+    return this.read();
+  }
+
+  async toggleTaskDone(id: string, doneBy: string): Promise<TimelineData> {
+    const data = await this.read();
+    const existing = (data.tasks ?? []).find(t => t.id === id);
+    if (!existing) return data;
+    const nowDone = !existing.done;
+    const update = {
+      done: nowDone,
+      done_at: nowDone ? new Date().toISOString() : null,
+      done_by: nowDone ? doneBy : null,
+    };
+    await this.client.from('timeline_tasks').update(update).eq('id', id);
+    await this.client.from('timeline_task_log').insert({
+      task_id: id,
+      actor: doneBy,
+      action: nowDone ? 'done:true' : 'done:false',
+      before_value: { done: existing.done },
+      after_value: update,
+    });
+    return this.read();
+  }
+
+  async removeTask(id: string): Promise<TimelineData> {
+    await this.client.from('timeline_tasks').delete().eq('id', id);
+    return this.read();
+  }
+}

--- a/web/src/lib/timeline/types.ts
+++ b/web/src/lib/timeline/types.ts
@@ -34,6 +34,23 @@ export interface TimelineEvent {
   needsClassification?: boolean;
 }
 
+export type TaskPriority = 'low' | 'med' | 'high';
+
+export interface SubTask {
+  id: string;
+  eventId?: string;          // 'ev-xxx' — null이면 unattached
+  title: string;
+  assignees: string[];       // displayName
+  reporter?: string;         // 작성자 email
+  dueDate?: string;          // 'YYYY-MM-DD'
+  priority?: TaskPriority;
+  done: boolean;
+  doneAt?: string;
+  doneBy?: string;           // displayName
+  sourceExcerpt?: string;
+  createdAt: string;
+}
+
 export interface ReusableAsset {
   id: string;
   title: string;
@@ -59,6 +76,16 @@ export interface GcalConfig {
   lastSyncAt?: string;
 }
 
+export interface TaskLogEntry {
+  id: string;
+  taskId: string;
+  actor: string;             // email or 'mother-bot' or display name
+  action: string;            // 'created' | 'done:true' | 'done:false' | 'removed' | 'updated:<field>'
+  before?: unknown;
+  after?: unknown;
+  createdAt: string;
+}
+
 export interface TimelineData {
   version: 1;
   updatedAt: string;
@@ -68,7 +95,15 @@ export interface TimelineData {
   lanes: TimelineLanesMeta;
   events: TimelineEvent[];
   reusableAssets: ReusableAsset[];
+  tasks?: SubTask[];
+  taskLog?: TaskLogEntry[];
   gcal?: GcalConfig;
+}
+
+export interface EventProgress {
+  total: number;
+  done: number;
+  overdue: number;
 }
 
 export interface Holiday {


### PR DESCRIPTION
기존 sheets-기반 dashboard 위에 task 기능만 가산. Supabase migration은 동봉 X — TIMELINE_STORE env 미설정 시 JsonFileStore 모드로 안정 동작 (production 안전).

Sub-task 체크리스트 (Jira-like 추적)
- TimelineData.tasks[] / taskLog[]: SubTask 모델 + audit
- TaskChecklist: 진척도 바 + 체크박스 + 한 줄 입력 (@멤버, M/D/ISO due, 긴급/낮음)
- EventCard에 done/total 미니바 (모든 view 공통)
- 본인 reporter만 task 삭제, reporter/assignee만 done 토글 (UI + server action)
- Server actions: addTask / toggleTaskDone / removeTask + router.refresh
- buildProgressMap: 이벤트별 done/total/overdue 계산
- Discord 알림 (DISCORD_TASK_WEBHOOK_URL 미설정 시 silent no-op)

@ 멤버 멘션 자동완성
- MentionInput: ArrowDown/Up keyup 시 index 0 reset 버그 수정 (same @ anchor + same query면 prev.index 보존)
- onEnter prop: 한 줄 입력에서 Enter로 submit (dropdown 닫힘 시)
- TaskChecklist도 plain input → MentionInput으로

cal-cli (skill 단일 진입점)
- env(TIMELINE_STORE) 분기 — sheets 환경에선 JsonFile 모드만 작동
- --dry-run 지원 (write 전 미리보기)
- event-{add,update,cancel,remove}, task-{add,done,undone,remove,list}

운영 안전 장치
- page.tsx loadTimeline: defaultStore().read() 사용 → write/read 경로 통일
- supabaseStore.ts는 코드 포함되지만 env opt-in 없으면 사용 X (dead code)
- Supabase migration/seed는 별도 dashboard-supabase 브랜치에만 존재